### PR TITLE
Add appendix links for branches

### DIFF
--- a/public/appendix/googlenet/3a.html
+++ b/public/appendix/googlenet/3a.html
@@ -5,21 +5,21 @@
   <meta charset="utf8">
   <script src="https://distill.pub/template.v2.js"></script>
   <style>
-  
+
     d-article {
       line-height: 1em;
     }
-    
+
     d-byline,
     d-appendix {
       display: none;
     }
-  
+
     h4 {
       display: block;
       width: 100%;
     }
-    
+
     d-figure {
       display: flex;
       flex-flow: row;
@@ -31,7 +31,7 @@
       margin-bottom: 1em;
       justify-content: center;
     }
-    
+
     .positive,
     .negative {
       display: flex;
@@ -40,7 +40,7 @@
       align-content: flex-start;
       max-width: 370px;
     }
-    
+
     .positive {
       padding-left: 1em;
       padding-right: 1em;
@@ -50,14 +50,14 @@
       border-right: 1px solid rgba(0,0,0,0.1);
       justify-content: space-between;
     }
-    
+
     .figcaption {
       display: block;
       color: rgba(0, 0, 0, 0.6);
       font-size: 12px;
       line-height: 1.5em;
     }
-    
+
     .diversity {
       display: flex;
       flex-flow: row;
@@ -65,61 +65,61 @@
       width: 148px;
       height: 147px
     }
-    
+
     .diversity > div {
       zoom: 0.496598639;
     }
-    
+
     .channel {
       margin-right: 1em;
     }
-    
+
     .channels {
       grid-column: screen;
       list-style: none;
       padding-left: 0;
     }
-    
+
     .channels li {
       contain: content;
       overflow: hidden;
     }
-    
+
     .sprite {
       display: inline-block;
       margin: 1px;
       width: 147px;
       height: 147px;
     }
-    
+
     .sprite.neuron {
       background-position-x: 0px;
     }
-    
+
     .sprite.channel {
       background-position-x: -147px;
     }
-    
+
     .sprite.channel-negative {
       background-position-x: -294px;
     }
-    
+
     .sprite.channel-diversity-0 {
       background-position-x: -441px;
     }
-    
+
     .sprite.channel-diversity-1 {
       background-position-x: -588px;
     }
-    
+
     .sprite.channel-diversity-2 {
       background-position-x: -735px;
     }
-    
+
     .sprite.channel-diversity-3 {
       background-position-x: -882px;
     }
-    
+
     .dataset-examples {
       display: flex;
       flex-flow: row;
@@ -127,7 +127,7 @@
       width: 375px;
       height: 147px
     }
-    
+
     .dataset-examples .sprite {
       height: 73px;
       width: 73px;
@@ -136,16 +136,16 @@
       margin-bottom: 0;
       margin-right: 0;
     }
-    
-    
+
+
       .channels .sprite.dataset-index-0 {
         background-position-x: -1029px !important;
       }
-      
+
       .channels .sprite.index-0 {
         background-position-y: -0px;
       }
-      
+
       .channels .dataset-negative .sprite.index-0 {
         background-position-y: -74px !important;
       }
@@ -153,11 +153,11 @@
       .channels .sprite.dataset-index-1 {
         background-position-x: -1103px !important;
       }
-      
+
       .channels .sprite.index-1 {
         background-position-y: -147px;
       }
-      
+
       .channels .dataset-negative .sprite.index-1 {
         background-position-y: -221px !important;
       }
@@ -165,11 +165,11 @@
       .channels .sprite.dataset-index-2 {
         background-position-x: -1177px !important;
       }
-      
+
       .channels .sprite.index-2 {
         background-position-y: -294px;
       }
-      
+
       .channels .dataset-negative .sprite.index-2 {
         background-position-y: -368px !important;
       }
@@ -177,11 +177,11 @@
       .channels .sprite.dataset-index-3 {
         background-position-x: -1251px !important;
       }
-      
+
       .channels .sprite.index-3 {
         background-position-y: -441px;
       }
-      
+
       .channels .dataset-negative .sprite.index-3 {
         background-position-y: -515px !important;
       }
@@ -189,11 +189,11 @@
       .channels .sprite.dataset-index-4 {
         background-position-x: -1325px !important;
       }
-      
+
       .channels .sprite.index-4 {
         background-position-y: -588px;
       }
-      
+
       .channels .dataset-negative .sprite.index-4 {
         background-position-y: -662px !important;
       }
@@ -201,11 +201,11 @@
       .channels .sprite.dataset-index-5 {
         background-position-x: -1399px !important;
       }
-      
+
       .channels .sprite.index-5 {
         background-position-y: -735px;
       }
-      
+
       .channels .dataset-negative .sprite.index-5 {
         background-position-y: -809px !important;
       }
@@ -213,11 +213,11 @@
       .channels .sprite.dataset-index-6 {
         background-position-x: -1473px !important;
       }
-      
+
       .channels .sprite.index-6 {
         background-position-y: -882px;
       }
-      
+
       .channels .dataset-negative .sprite.index-6 {
         background-position-y: -956px !important;
       }
@@ -225,11 +225,11 @@
       .channels .sprite.dataset-index-7 {
         background-position-x: -1547px !important;
       }
-      
+
       .channels .sprite.index-7 {
         background-position-y: -1029px;
       }
-      
+
       .channels .dataset-negative .sprite.index-7 {
         background-position-y: -1103px !important;
       }
@@ -237,11 +237,11 @@
       .channels .sprite.dataset-index-8 {
         background-position-x: -1621px !important;
       }
-      
+
       .channels .sprite.index-8 {
         background-position-y: -1176px;
       }
-      
+
       .channels .dataset-negative .sprite.index-8 {
         background-position-y: -1250px !important;
       }
@@ -249,20 +249,20 @@
       .channels .sprite.dataset-index-9 {
         background-position-x: -1695px !important;
       }
-      
+
       .channels .sprite.index-9 {
         background-position-y: -1323px;
       }
-      
+
       .channels .dataset-negative .sprite.index-9 {
         background-position-y: -1397px !important;
       }
-    
-    
+
+
     .article-nav {
       grid-column: page;
     }
-    
+
     .navlist li {
       display: inline;
       list-style-type: none;
@@ -300,17 +300,17 @@
     <h1>Layer 3a</h1>
   </d-title>
   <d-article>
-  
+
   <nav class="article-nav">
-  
-    
+
+
     <ul class="navlist">
       <li><a href="https://distill.pub/2017/feature-visualization/appendix/">Appendix overview</a></li>
       <li><a href="https://distill.pub/2017/feature-visualization/">Main article</a></li>
     </ul>
     <ul class="navlist">
       <li>
-        <a href="3a.html">Layer 3a</a>
+        <a href="3a.html"><b>Layer 3a</b></a>
       </li>
       <li>
         <a href="3b.html">Layer 3b</a>
@@ -337,14 +337,21 @@
         <a href="5b.html">Layer 5b</a>
       </li>
     </ul>
-  
+
+    <ul class="navlist">
+      <li> <a href="3a.html#3a-0">3a 1x1</a> <span style="color: #777;"> (0:64)</span> </li>
+      <li> <a href="3a.html#3a-64">3a 3x3</a> <span style="color: #777;"> (64:192)</span> </li>
+      <li> <a href="3a.html#3a-192">3a 5x5</a> <span style="color: #777;"> (192:224)</span> </li>
+      <li> <a href="3a.html#3a-224">3a pool</a> <span style="color: #777;"> (224:256)</span> </li>
+    </ul>
+
   </nav>
-  
+
   <hr style="margin-top: 20px;"/>
-  
+
   <ul class="channels">
     <!--mixed3a-00000--mixed3a-00009.jpg-->
-    
+
       <li id="channel-0">
       <d-figure id="3a-0">
       <style data-img-src="images/mixed3a-00000--mixed3a-00009.jpg" data-channel="0"></style>
@@ -359,7 +366,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -369,7 +376,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -426,7 +433,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -436,7 +443,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -493,7 +500,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -503,7 +510,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -560,7 +567,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -570,7 +577,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -627,7 +634,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -637,7 +644,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -694,7 +701,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -704,7 +711,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -761,7 +768,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -771,7 +778,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -828,7 +835,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -838,7 +845,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -895,7 +902,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -905,7 +912,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -962,7 +969,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -972,7 +979,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -1014,9 +1021,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3a-00010--mixed3a-00019.jpg-->
-    
+
 
 
 
@@ -1041,7 +1048,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -1051,7 +1058,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -1108,7 +1115,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -1118,7 +1125,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -1175,7 +1182,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -1185,7 +1192,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -1242,7 +1249,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -1252,7 +1259,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -1309,7 +1316,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -1319,7 +1326,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -1376,7 +1383,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -1386,7 +1393,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -1443,7 +1450,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -1453,7 +1460,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -1510,7 +1517,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -1520,7 +1527,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -1577,7 +1584,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -1587,7 +1594,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -1644,7 +1651,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -1654,7 +1661,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -1696,9 +1703,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3a-00020--mixed3a-00029.jpg-->
-    
+
 
 
 
@@ -1733,7 +1740,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -1743,7 +1750,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -1800,7 +1807,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -1810,7 +1817,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -1867,7 +1874,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -1877,7 +1884,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -1934,7 +1941,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -1944,7 +1951,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -2001,7 +2008,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -2011,7 +2018,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -2068,7 +2075,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -2078,7 +2085,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -2135,7 +2142,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -2145,7 +2152,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -2202,7 +2209,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -2212,7 +2219,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -2269,7 +2276,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -2279,7 +2286,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -2336,7 +2343,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -2346,7 +2353,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -2388,9 +2395,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3a-00030--mixed3a-00039.jpg-->
-    
+
 
 
 
@@ -2435,7 +2442,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -2445,7 +2452,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -2502,7 +2509,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -2512,7 +2519,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -2569,7 +2576,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -2579,7 +2586,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -2636,7 +2643,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -2646,7 +2653,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -2703,7 +2710,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -2713,7 +2720,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -2770,7 +2777,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -2780,7 +2787,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -2837,7 +2844,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -2847,7 +2854,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -2904,7 +2911,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -2914,7 +2921,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -2971,7 +2978,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -2981,7 +2988,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -3038,7 +3045,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -3048,7 +3055,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -3090,9 +3097,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3a-00040--mixed3a-00049.jpg-->
-    
+
 
 
 
@@ -3147,7 +3154,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -3157,7 +3164,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -3214,7 +3221,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -3224,7 +3231,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -3281,7 +3288,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -3291,7 +3298,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -3348,7 +3355,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -3358,7 +3365,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -3415,7 +3422,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -3425,7 +3432,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -3482,7 +3489,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -3492,7 +3499,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -3549,7 +3556,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -3559,7 +3566,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -3616,7 +3623,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -3626,7 +3633,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -3683,7 +3690,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -3693,7 +3700,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -3750,7 +3757,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -3760,7 +3767,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -3802,9 +3809,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3a-00050--mixed3a-00059.jpg-->
-    
+
 
 
 
@@ -3869,7 +3876,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -3879,7 +3886,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -3936,7 +3943,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -3946,7 +3953,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -4003,7 +4010,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -4013,7 +4020,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -4070,7 +4077,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -4080,7 +4087,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -4137,7 +4144,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -4147,7 +4154,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -4204,7 +4211,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -4214,7 +4221,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -4271,7 +4278,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -4281,7 +4288,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -4338,7 +4345,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -4348,7 +4355,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -4405,7 +4412,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -4415,7 +4422,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -4472,7 +4479,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -4482,7 +4489,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -4524,9 +4531,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3a-00060--mixed3a-00069.jpg-->
-    
+
 
 
 
@@ -4601,7 +4608,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -4611,7 +4618,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -4668,7 +4675,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -4678,7 +4685,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -4735,7 +4742,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -4745,7 +4752,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -4802,7 +4809,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -4812,7 +4819,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -4869,7 +4876,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -4879,7 +4886,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -4936,7 +4943,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -4946,7 +4953,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -5003,7 +5010,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -5013,7 +5020,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -5070,7 +5077,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -5080,7 +5087,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -5137,7 +5144,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -5147,7 +5154,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -5204,7 +5211,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -5214,7 +5221,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -5256,9 +5263,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3a-00070--mixed3a-00079.jpg-->
-    
+
 
 
 
@@ -5343,7 +5350,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -5353,7 +5360,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -5410,7 +5417,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -5420,7 +5427,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -5477,7 +5484,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -5487,7 +5494,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -5544,7 +5551,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -5554,7 +5561,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -5611,7 +5618,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -5621,7 +5628,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -5678,7 +5685,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -5688,7 +5695,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -5745,7 +5752,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -5755,7 +5762,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -5812,7 +5819,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -5822,7 +5829,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -5879,7 +5886,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -5889,7 +5896,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -5946,7 +5953,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -5956,7 +5963,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -5998,9 +6005,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3a-00080--mixed3a-00089.jpg-->
-    
+
 
 
 
@@ -6095,7 +6102,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -6105,7 +6112,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -6162,7 +6169,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -6172,7 +6179,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -6229,7 +6236,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -6239,7 +6246,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -6296,7 +6303,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -6306,7 +6313,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -6363,7 +6370,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -6373,7 +6380,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -6430,7 +6437,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -6440,7 +6447,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -6497,7 +6504,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -6507,7 +6514,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -6564,7 +6571,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -6574,7 +6581,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -6631,7 +6638,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -6641,7 +6648,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -6698,7 +6705,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -6708,7 +6715,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -6750,9 +6757,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3a-00090--mixed3a-00099.jpg-->
-    
+
 
 
 
@@ -6857,7 +6864,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -6867,7 +6874,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -6924,7 +6931,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -6934,7 +6941,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -6991,7 +6998,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -7001,7 +7008,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -7058,7 +7065,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -7068,7 +7075,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -7125,7 +7132,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -7135,7 +7142,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -7192,7 +7199,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -7202,7 +7209,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -7259,7 +7266,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -7269,7 +7276,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -7326,7 +7333,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -7336,7 +7343,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -7393,7 +7400,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -7403,7 +7410,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -7460,7 +7467,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -7470,7 +7477,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -7512,9 +7519,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3a-00100--mixed3a-00109.jpg-->
-    
+
 
 
 
@@ -7629,7 +7636,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -7639,7 +7646,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -7696,7 +7703,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -7706,7 +7713,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -7763,7 +7770,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -7773,7 +7780,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -7830,7 +7837,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -7840,7 +7847,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -7897,7 +7904,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -7907,7 +7914,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -7964,7 +7971,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -7974,7 +7981,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -8031,7 +8038,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -8041,7 +8048,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -8098,7 +8105,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -8108,7 +8115,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -8165,7 +8172,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -8175,7 +8182,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -8232,7 +8239,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -8242,7 +8249,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -8284,9 +8291,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3a-00110--mixed3a-00119.jpg-->
-    
+
 
 
 
@@ -8411,7 +8418,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -8421,7 +8428,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -8478,7 +8485,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -8488,7 +8495,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -8545,7 +8552,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -8555,7 +8562,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -8612,7 +8619,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -8622,7 +8629,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -8679,7 +8686,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -8689,7 +8696,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -8746,7 +8753,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -8756,7 +8763,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -8813,7 +8820,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -8823,7 +8830,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -8880,7 +8887,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -8890,7 +8897,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -8947,7 +8954,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -8957,7 +8964,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -9014,7 +9021,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -9024,7 +9031,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -9066,9 +9073,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3a-00120--mixed3a-00129.jpg-->
-    
+
 
 
 
@@ -9203,7 +9210,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -9213,7 +9220,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -9270,7 +9277,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -9280,7 +9287,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -9337,7 +9344,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -9347,7 +9354,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -9404,7 +9411,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -9414,7 +9421,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -9471,7 +9478,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -9481,7 +9488,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -9538,7 +9545,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -9548,7 +9555,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -9605,7 +9612,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -9615,7 +9622,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -9672,7 +9679,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -9682,7 +9689,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -9739,7 +9746,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -9749,7 +9756,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -9806,7 +9813,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -9816,7 +9823,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -9858,9 +9865,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3a-00130--mixed3a-00139.jpg-->
-    
+
 
 
 
@@ -10005,7 +10012,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -10015,7 +10022,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -10072,7 +10079,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -10082,7 +10089,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -10139,7 +10146,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -10149,7 +10156,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -10206,7 +10213,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -10216,7 +10223,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -10273,7 +10280,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -10283,7 +10290,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -10340,7 +10347,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -10350,7 +10357,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -10407,7 +10414,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -10417,7 +10424,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -10474,7 +10481,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -10484,7 +10491,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -10541,7 +10548,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -10551,7 +10558,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -10608,7 +10615,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -10618,7 +10625,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -10660,9 +10667,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3a-00140--mixed3a-00149.jpg-->
-    
+
 
 
 
@@ -10817,7 +10824,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -10827,7 +10834,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -10884,7 +10891,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -10894,7 +10901,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -10951,7 +10958,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -10961,7 +10968,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -11018,7 +11025,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -11028,7 +11035,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -11085,7 +11092,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -11095,7 +11102,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -11152,7 +11159,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -11162,7 +11169,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -11219,7 +11226,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -11229,7 +11236,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -11286,7 +11293,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -11296,7 +11303,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -11353,7 +11360,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -11363,7 +11370,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -11420,7 +11427,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -11430,7 +11437,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -11472,9 +11479,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3a-00150--mixed3a-00159.jpg-->
-    
+
 
 
 
@@ -11639,7 +11646,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -11649,7 +11656,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -11706,7 +11713,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -11716,7 +11723,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -11773,7 +11780,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -11783,7 +11790,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -11840,7 +11847,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -11850,7 +11857,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -11907,7 +11914,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -11917,7 +11924,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -11974,7 +11981,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -11984,7 +11991,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -12041,7 +12048,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -12051,7 +12058,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -12108,7 +12115,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -12118,7 +12125,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -12175,7 +12182,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -12185,7 +12192,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -12242,7 +12249,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -12252,7 +12259,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -12294,9 +12301,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3a-00160--mixed3a-00169.jpg-->
-    
+
 
 
 
@@ -12471,7 +12478,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -12481,7 +12488,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -12538,7 +12545,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -12548,7 +12555,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -12605,7 +12612,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -12615,7 +12622,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -12672,7 +12679,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -12682,7 +12689,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -12739,7 +12746,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -12749,7 +12756,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -12806,7 +12813,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -12816,7 +12823,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -12873,7 +12880,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -12883,7 +12890,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -12940,7 +12947,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -12950,7 +12957,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -13007,7 +13014,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -13017,7 +13024,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -13074,7 +13081,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -13084,7 +13091,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -13126,9 +13133,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3a-00170--mixed3a-00179.jpg-->
-    
+
 
 
 
@@ -13313,7 +13320,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -13323,7 +13330,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -13380,7 +13387,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -13390,7 +13397,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -13447,7 +13454,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -13457,7 +13464,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -13514,7 +13521,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -13524,7 +13531,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -13581,7 +13588,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -13591,7 +13598,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -13648,7 +13655,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -13658,7 +13665,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -13715,7 +13722,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -13725,7 +13732,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -13782,7 +13789,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -13792,7 +13799,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -13849,7 +13856,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -13859,7 +13866,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -13916,7 +13923,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -13926,7 +13933,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -13968,9 +13975,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3a-00180--mixed3a-00189.jpg-->
-    
+
 
 
 
@@ -14165,7 +14172,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -14175,7 +14182,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -14232,7 +14239,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -14242,7 +14249,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -14299,7 +14306,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -14309,7 +14316,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -14366,7 +14373,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -14376,7 +14383,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -14433,7 +14440,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -14443,7 +14450,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -14500,7 +14507,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -14510,7 +14517,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -14567,7 +14574,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -14577,7 +14584,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -14634,7 +14641,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -14644,7 +14651,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -14701,7 +14708,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -14711,7 +14718,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -14768,7 +14775,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -14778,7 +14785,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -14820,9 +14827,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3a-00190--mixed3a-00199.jpg-->
-    
+
 
 
 
@@ -15027,7 +15034,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -15037,7 +15044,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -15094,7 +15101,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -15104,7 +15111,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -15161,7 +15168,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -15171,7 +15178,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -15228,7 +15235,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -15238,7 +15245,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -15295,7 +15302,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -15305,7 +15312,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -15362,7 +15369,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -15372,7 +15379,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -15429,7 +15436,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -15439,7 +15446,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -15496,7 +15503,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -15506,7 +15513,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -15563,7 +15570,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -15573,7 +15580,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -15630,7 +15637,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -15640,7 +15647,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -15682,9 +15689,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3a-00200--mixed3a-00209.jpg-->
-    
+
 
 
 
@@ -15899,7 +15906,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -15909,7 +15916,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -15966,7 +15973,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -15976,7 +15983,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -16033,7 +16040,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -16043,7 +16050,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -16100,7 +16107,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -16110,7 +16117,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -16167,7 +16174,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -16177,7 +16184,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -16234,7 +16241,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -16244,7 +16251,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -16301,7 +16308,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -16311,7 +16318,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -16368,7 +16375,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -16378,7 +16385,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -16435,7 +16442,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -16445,7 +16452,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -16502,7 +16509,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -16512,7 +16519,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -16554,9 +16561,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3a-00210--mixed3a-00219.jpg-->
-    
+
 
 
 
@@ -16781,7 +16788,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -16791,7 +16798,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -16848,7 +16855,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -16858,7 +16865,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -16915,7 +16922,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -16925,7 +16932,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -16982,7 +16989,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -16992,7 +16999,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -17049,7 +17056,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -17059,7 +17066,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -17116,7 +17123,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -17126,7 +17133,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -17183,7 +17190,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -17193,7 +17200,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -17250,7 +17257,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -17260,7 +17267,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -17317,7 +17324,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -17327,7 +17334,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -17384,7 +17391,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -17394,7 +17401,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -17436,9 +17443,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3a-00220--mixed3a-00229.jpg-->
-    
+
 
 
 
@@ -17673,7 +17680,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -17683,7 +17690,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -17740,7 +17747,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -17750,7 +17757,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -17807,7 +17814,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -17817,7 +17824,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -17874,7 +17881,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -17884,7 +17891,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -17941,7 +17948,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -17951,7 +17958,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -18008,7 +18015,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -18018,7 +18025,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -18075,7 +18082,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -18085,7 +18092,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -18142,7 +18149,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -18152,7 +18159,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -18209,7 +18216,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -18219,7 +18226,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -18276,7 +18283,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -18286,7 +18293,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -18328,9 +18335,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3a-00230--mixed3a-00239.jpg-->
-    
+
 
 
 
@@ -18575,7 +18582,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -18585,7 +18592,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -18642,7 +18649,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -18652,7 +18659,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -18709,7 +18716,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -18719,7 +18726,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -18776,7 +18783,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -18786,7 +18793,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -18843,7 +18850,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -18853,7 +18860,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -18910,7 +18917,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -18920,7 +18927,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -18977,7 +18984,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -18987,7 +18994,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -19044,7 +19051,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -19054,7 +19061,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -19111,7 +19118,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -19121,7 +19128,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -19178,7 +19185,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -19188,7 +19195,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -19230,9 +19237,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3a-00240--mixed3a-00249.jpg-->
-    
+
 
 
 
@@ -19487,7 +19494,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -19497,7 +19504,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -19554,7 +19561,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -19564,7 +19571,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -19621,7 +19628,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -19631,7 +19638,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -19688,7 +19695,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -19698,7 +19705,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -19755,7 +19762,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -19765,7 +19772,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -19822,7 +19829,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -19832,7 +19839,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -19889,7 +19896,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -19899,7 +19906,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -19956,7 +19963,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -19966,7 +19973,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -20023,7 +20030,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -20033,7 +20040,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -20090,7 +20097,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -20100,7 +20107,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -20142,9 +20149,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3a-00250--mixed3a-00255.jpg-->
-    
+
 
 
 
@@ -20409,7 +20416,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -20419,7 +20426,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -20476,7 +20483,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -20486,7 +20493,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -20543,7 +20550,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -20553,7 +20560,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -20610,7 +20617,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -20620,7 +20627,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -20677,7 +20684,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -20687,7 +20694,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -20744,7 +20751,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -20754,7 +20761,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -20796,9 +20803,8 @@
       </div>
       </d-figure>
       </li>
-  
+
   </ul>
   </d-article>
   <distill-footer></distill-footer>
 </body>
-  

--- a/public/appendix/googlenet/3b.html
+++ b/public/appendix/googlenet/3b.html
@@ -5,21 +5,21 @@
   <meta charset="utf8">
   <script src="https://distill.pub/template.v2.js"></script>
   <style>
-  
+
     d-article {
       line-height: 1em;
     }
-    
+
     d-byline,
     d-appendix {
       display: none;
     }
-  
+
     h4 {
       display: block;
       width: 100%;
     }
-    
+
     d-figure {
       display: flex;
       flex-flow: row;
@@ -31,7 +31,7 @@
       margin-bottom: 1em;
       justify-content: center;
     }
-    
+
     .positive,
     .negative {
       display: flex;
@@ -40,7 +40,7 @@
       align-content: flex-start;
       max-width: 370px;
     }
-    
+
     .positive {
       padding-left: 1em;
       padding-right: 1em;
@@ -50,14 +50,14 @@
       border-right: 1px solid rgba(0,0,0,0.1);
       justify-content: space-between;
     }
-    
+
     .figcaption {
       display: block;
       color: rgba(0, 0, 0, 0.6);
       font-size: 12px;
       line-height: 1.5em;
     }
-    
+
     .diversity {
       display: flex;
       flex-flow: row;
@@ -65,61 +65,61 @@
       width: 148px;
       height: 147px
     }
-    
+
     .diversity > div {
       zoom: 0.496598639;
     }
-    
+
     .channel {
       margin-right: 1em;
     }
-    
+
     .channels {
       grid-column: screen;
       list-style: none;
       padding-left: 0;
     }
-    
+
     .channels li {
       contain: content;
       overflow: hidden;
     }
-    
+
     .sprite {
       display: inline-block;
       margin: 1px;
       width: 147px;
       height: 147px;
     }
-    
+
     .sprite.neuron {
       background-position-x: 0px;
     }
-    
+
     .sprite.channel {
       background-position-x: -147px;
     }
-    
+
     .sprite.channel-negative {
       background-position-x: -294px;
     }
-    
+
     .sprite.channel-diversity-0 {
       background-position-x: -441px;
     }
-    
+
     .sprite.channel-diversity-1 {
       background-position-x: -588px;
     }
-    
+
     .sprite.channel-diversity-2 {
       background-position-x: -735px;
     }
-    
+
     .sprite.channel-diversity-3 {
       background-position-x: -882px;
     }
-    
+
     .dataset-examples {
       display: flex;
       flex-flow: row;
@@ -127,7 +127,7 @@
       width: 375px;
       height: 147px
     }
-    
+
     .dataset-examples .sprite {
       height: 73px;
       width: 73px;
@@ -136,16 +136,16 @@
       margin-bottom: 0;
       margin-right: 0;
     }
-    
-    
+
+
       .channels .sprite.dataset-index-0 {
         background-position-x: -1029px !important;
       }
-      
+
       .channels .sprite.index-0 {
         background-position-y: -0px;
       }
-      
+
       .channels .dataset-negative .sprite.index-0 {
         background-position-y: -74px !important;
       }
@@ -153,11 +153,11 @@
       .channels .sprite.dataset-index-1 {
         background-position-x: -1103px !important;
       }
-      
+
       .channels .sprite.index-1 {
         background-position-y: -147px;
       }
-      
+
       .channels .dataset-negative .sprite.index-1 {
         background-position-y: -221px !important;
       }
@@ -165,11 +165,11 @@
       .channels .sprite.dataset-index-2 {
         background-position-x: -1177px !important;
       }
-      
+
       .channels .sprite.index-2 {
         background-position-y: -294px;
       }
-      
+
       .channels .dataset-negative .sprite.index-2 {
         background-position-y: -368px !important;
       }
@@ -177,11 +177,11 @@
       .channels .sprite.dataset-index-3 {
         background-position-x: -1251px !important;
       }
-      
+
       .channels .sprite.index-3 {
         background-position-y: -441px;
       }
-      
+
       .channels .dataset-negative .sprite.index-3 {
         background-position-y: -515px !important;
       }
@@ -189,11 +189,11 @@
       .channels .sprite.dataset-index-4 {
         background-position-x: -1325px !important;
       }
-      
+
       .channels .sprite.index-4 {
         background-position-y: -588px;
       }
-      
+
       .channels .dataset-negative .sprite.index-4 {
         background-position-y: -662px !important;
       }
@@ -201,11 +201,11 @@
       .channels .sprite.dataset-index-5 {
         background-position-x: -1399px !important;
       }
-      
+
       .channels .sprite.index-5 {
         background-position-y: -735px;
       }
-      
+
       .channels .dataset-negative .sprite.index-5 {
         background-position-y: -809px !important;
       }
@@ -213,11 +213,11 @@
       .channels .sprite.dataset-index-6 {
         background-position-x: -1473px !important;
       }
-      
+
       .channels .sprite.index-6 {
         background-position-y: -882px;
       }
-      
+
       .channels .dataset-negative .sprite.index-6 {
         background-position-y: -956px !important;
       }
@@ -225,11 +225,11 @@
       .channels .sprite.dataset-index-7 {
         background-position-x: -1547px !important;
       }
-      
+
       .channels .sprite.index-7 {
         background-position-y: -1029px;
       }
-      
+
       .channels .dataset-negative .sprite.index-7 {
         background-position-y: -1103px !important;
       }
@@ -237,11 +237,11 @@
       .channels .sprite.dataset-index-8 {
         background-position-x: -1621px !important;
       }
-      
+
       .channels .sprite.index-8 {
         background-position-y: -1176px;
       }
-      
+
       .channels .dataset-negative .sprite.index-8 {
         background-position-y: -1250px !important;
       }
@@ -249,20 +249,20 @@
       .channels .sprite.dataset-index-9 {
         background-position-x: -1695px !important;
       }
-      
+
       .channels .sprite.index-9 {
         background-position-y: -1323px;
       }
-      
+
       .channels .dataset-negative .sprite.index-9 {
         background-position-y: -1397px !important;
       }
-    
-    
+
+
     .article-nav {
       grid-column: page;
     }
-    
+
     .navlist li {
       display: inline;
       list-style-type: none;
@@ -300,10 +300,10 @@
     <h1>Layer 3b</h1>
   </d-title>
   <d-article>
-  
+
   <nav class="article-nav">
-  
-    
+
+
     <ul class="navlist">
       <li><a href="https://distill.pub/2017/feature-visualization/appendix/">Appendix overview</a></li>
       <li><a href="https://distill.pub/2017/feature-visualization/">Main article</a></li>
@@ -313,7 +313,7 @@
         <a href="3a.html">Layer 3a</a>
       </li>
       <li>
-        <a href="3b.html">Layer 3b</a>
+        <a href="3b.html"><b>Layer 3b</b></a>
       </li>
       <li>
         <a href="4a.html">Layer 4a</a>
@@ -337,14 +337,21 @@
         <a href="5b.html">Layer 5b</a>
       </li>
     </ul>
-  
+
+    <ul class="navlist">
+      <li> <a href="3b.html#3b-0">3b 1x1</a> <span style="color: #777;">(0:128)</span> </li>
+      <li> <a href="3b.html#3b-128">3b 3x3</a> <span style="color: #777;">(128:320)</span> </li>
+      <li> <a href="3b.html#3b-320">3b 5x5</a> <span style="color: #777;">(320:416)</span> </li>
+      <li> <a href="3b.html#3b-416">3b pool</a> <span style="color: #777;">(416:480)</span> </li>
+    </ul>
+
   </nav>
-  
+
   <hr style="margin-top: 20px;"/>
-  
+
   <ul class="channels">
     <!--mixed3b-00000--mixed3b-00009.jpg-->
-    
+
       <li id="channel-0">
       <d-figure id="3b-0">
       <style data-img-src="images/mixed3b-00000--mixed3b-00009.jpg" data-channel="0"></style>
@@ -359,7 +366,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -369,7 +376,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -426,7 +433,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -436,7 +443,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -493,7 +500,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -503,7 +510,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -560,7 +567,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -570,7 +577,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -627,7 +634,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -637,7 +644,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -694,7 +701,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -704,7 +711,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -761,7 +768,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -771,7 +778,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -828,7 +835,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -838,7 +845,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -895,7 +902,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -905,7 +912,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -962,7 +969,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -972,7 +979,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -1014,9 +1021,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00010--mixed3b-00019.jpg-->
-    
+
 
 
 
@@ -1041,7 +1048,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -1051,7 +1058,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -1108,7 +1115,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -1118,7 +1125,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -1175,7 +1182,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -1185,7 +1192,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -1242,7 +1249,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -1252,7 +1259,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -1309,7 +1316,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -1319,7 +1326,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -1376,7 +1383,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -1386,7 +1393,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -1443,7 +1450,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -1453,7 +1460,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -1510,7 +1517,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -1520,7 +1527,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -1577,7 +1584,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -1587,7 +1594,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -1644,7 +1651,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -1654,7 +1661,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -1696,9 +1703,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00020--mixed3b-00029.jpg-->
-    
+
 
 
 
@@ -1733,7 +1740,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -1743,7 +1750,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -1800,7 +1807,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -1810,7 +1817,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -1867,7 +1874,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -1877,7 +1884,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -1934,7 +1941,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -1944,7 +1951,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -2001,7 +2008,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -2011,7 +2018,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -2068,7 +2075,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -2078,7 +2085,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -2135,7 +2142,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -2145,7 +2152,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -2202,7 +2209,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -2212,7 +2219,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -2269,7 +2276,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -2279,7 +2286,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -2336,7 +2343,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -2346,7 +2353,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -2388,9 +2395,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00030--mixed3b-00039.jpg-->
-    
+
 
 
 
@@ -2435,7 +2442,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -2445,7 +2452,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -2502,7 +2509,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -2512,7 +2519,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -2569,7 +2576,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -2579,7 +2586,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -2636,7 +2643,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -2646,7 +2653,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -2703,7 +2710,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -2713,7 +2720,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -2770,7 +2777,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -2780,7 +2787,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -2837,7 +2844,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -2847,7 +2854,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -2904,7 +2911,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -2914,7 +2921,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -2971,7 +2978,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -2981,7 +2988,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -3038,7 +3045,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -3048,7 +3055,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -3090,9 +3097,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00040--mixed3b-00049.jpg-->
-    
+
 
 
 
@@ -3147,7 +3154,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -3157,7 +3164,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -3214,7 +3221,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -3224,7 +3231,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -3281,7 +3288,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -3291,7 +3298,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -3348,7 +3355,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -3358,7 +3365,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -3415,7 +3422,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -3425,7 +3432,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -3482,7 +3489,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -3492,7 +3499,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -3549,7 +3556,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -3559,7 +3566,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -3616,7 +3623,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -3626,7 +3633,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -3683,7 +3690,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -3693,7 +3700,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -3750,7 +3757,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -3760,7 +3767,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -3802,9 +3809,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00050--mixed3b-00059.jpg-->
-    
+
 
 
 
@@ -3869,7 +3876,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -3879,7 +3886,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -3936,7 +3943,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -3946,7 +3953,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -4003,7 +4010,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -4013,7 +4020,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -4070,7 +4077,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -4080,7 +4087,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -4137,7 +4144,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -4147,7 +4154,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -4204,7 +4211,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -4214,7 +4221,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -4271,7 +4278,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -4281,7 +4288,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -4338,7 +4345,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -4348,7 +4355,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -4405,7 +4412,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -4415,7 +4422,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -4472,7 +4479,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -4482,7 +4489,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -4524,9 +4531,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00060--mixed3b-00069.jpg-->
-    
+
 
 
 
@@ -4601,7 +4608,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -4611,7 +4618,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -4668,7 +4675,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -4678,7 +4685,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -4735,7 +4742,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -4745,7 +4752,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -4802,7 +4809,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -4812,7 +4819,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -4869,7 +4876,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -4879,7 +4886,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -4936,7 +4943,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -4946,7 +4953,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -5003,7 +5010,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -5013,7 +5020,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -5070,7 +5077,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -5080,7 +5087,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -5137,7 +5144,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -5147,7 +5154,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -5204,7 +5211,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -5214,7 +5221,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -5256,9 +5263,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00070--mixed3b-00079.jpg-->
-    
+
 
 
 
@@ -5343,7 +5350,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -5353,7 +5360,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -5410,7 +5417,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -5420,7 +5427,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -5477,7 +5484,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -5487,7 +5494,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -5544,7 +5551,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -5554,7 +5561,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -5611,7 +5618,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -5621,7 +5628,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -5678,7 +5685,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -5688,7 +5695,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -5745,7 +5752,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -5755,7 +5762,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -5812,7 +5819,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -5822,7 +5829,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -5879,7 +5886,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -5889,7 +5896,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -5946,7 +5953,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -5956,7 +5963,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -5998,9 +6005,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00080--mixed3b-00089.jpg-->
-    
+
 
 
 
@@ -6095,7 +6102,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -6105,7 +6112,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -6162,7 +6169,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -6172,7 +6179,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -6229,7 +6236,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -6239,7 +6246,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -6296,7 +6303,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -6306,7 +6313,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -6363,7 +6370,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -6373,7 +6380,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -6430,7 +6437,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -6440,7 +6447,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -6497,7 +6504,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -6507,7 +6514,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -6564,7 +6571,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -6574,7 +6581,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -6631,7 +6638,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -6641,7 +6648,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -6698,7 +6705,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -6708,7 +6715,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -6750,9 +6757,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00090--mixed3b-00099.jpg-->
-    
+
 
 
 
@@ -6857,7 +6864,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -6867,7 +6874,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -6924,7 +6931,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -6934,7 +6941,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -6991,7 +6998,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -7001,7 +7008,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -7058,7 +7065,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -7068,7 +7075,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -7125,7 +7132,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -7135,7 +7142,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -7192,7 +7199,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -7202,7 +7209,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -7259,7 +7266,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -7269,7 +7276,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -7326,7 +7333,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -7336,7 +7343,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -7393,7 +7400,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -7403,7 +7410,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -7460,7 +7467,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -7470,7 +7477,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -7512,9 +7519,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00100--mixed3b-00109.jpg-->
-    
+
 
 
 
@@ -7629,7 +7636,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -7639,7 +7646,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -7696,7 +7703,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -7706,7 +7713,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -7763,7 +7770,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -7773,7 +7780,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -7830,7 +7837,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -7840,7 +7847,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -7897,7 +7904,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -7907,7 +7914,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -7964,7 +7971,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -7974,7 +7981,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -8031,7 +8038,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -8041,7 +8048,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -8098,7 +8105,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -8108,7 +8115,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -8165,7 +8172,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -8175,7 +8182,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -8232,7 +8239,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -8242,7 +8249,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -8284,9 +8291,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00110--mixed3b-00119.jpg-->
-    
+
 
 
 
@@ -8411,7 +8418,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -8421,7 +8428,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -8478,7 +8485,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -8488,7 +8495,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -8545,7 +8552,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -8555,7 +8562,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -8612,7 +8619,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -8622,7 +8629,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -8679,7 +8686,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -8689,7 +8696,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -8746,7 +8753,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -8756,7 +8763,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -8813,7 +8820,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -8823,7 +8830,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -8880,7 +8887,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -8890,7 +8897,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -8947,7 +8954,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -8957,7 +8964,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -9014,7 +9021,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -9024,7 +9031,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -9066,9 +9073,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00120--mixed3b-00129.jpg-->
-    
+
 
 
 
@@ -9203,7 +9210,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -9213,7 +9220,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -9270,7 +9277,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -9280,7 +9287,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -9337,7 +9344,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -9347,7 +9354,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -9404,7 +9411,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -9414,7 +9421,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -9471,7 +9478,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -9481,7 +9488,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -9538,7 +9545,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -9548,7 +9555,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -9605,7 +9612,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -9615,7 +9622,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -9672,7 +9679,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -9682,7 +9689,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -9739,7 +9746,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -9749,7 +9756,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -9806,7 +9813,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -9816,7 +9823,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -9858,9 +9865,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00130--mixed3b-00139.jpg-->
-    
+
 
 
 
@@ -10005,7 +10012,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -10015,7 +10022,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -10072,7 +10079,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -10082,7 +10089,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -10139,7 +10146,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -10149,7 +10156,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -10206,7 +10213,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -10216,7 +10223,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -10273,7 +10280,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -10283,7 +10290,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -10340,7 +10347,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -10350,7 +10357,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -10407,7 +10414,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -10417,7 +10424,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -10474,7 +10481,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -10484,7 +10491,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -10541,7 +10548,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -10551,7 +10558,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -10608,7 +10615,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -10618,7 +10625,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -10660,9 +10667,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00140--mixed3b-00149.jpg-->
-    
+
 
 
 
@@ -10817,7 +10824,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -10827,7 +10834,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -10884,7 +10891,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -10894,7 +10901,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -10951,7 +10958,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -10961,7 +10968,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -11018,7 +11025,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -11028,7 +11035,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -11085,7 +11092,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -11095,7 +11102,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -11152,7 +11159,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -11162,7 +11169,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -11219,7 +11226,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -11229,7 +11236,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -11286,7 +11293,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -11296,7 +11303,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -11353,7 +11360,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -11363,7 +11370,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -11420,7 +11427,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -11430,7 +11437,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -11472,9 +11479,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00150--mixed3b-00159.jpg-->
-    
+
 
 
 
@@ -11639,7 +11646,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -11649,7 +11656,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -11706,7 +11713,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -11716,7 +11723,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -11773,7 +11780,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -11783,7 +11790,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -11840,7 +11847,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -11850,7 +11857,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -11907,7 +11914,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -11917,7 +11924,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -11974,7 +11981,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -11984,7 +11991,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -12041,7 +12048,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -12051,7 +12058,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -12108,7 +12115,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -12118,7 +12125,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -12175,7 +12182,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -12185,7 +12192,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -12242,7 +12249,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -12252,7 +12259,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -12294,9 +12301,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00160--mixed3b-00169.jpg-->
-    
+
 
 
 
@@ -12471,7 +12478,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -12481,7 +12488,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -12538,7 +12545,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -12548,7 +12555,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -12605,7 +12612,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -12615,7 +12622,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -12672,7 +12679,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -12682,7 +12689,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -12739,7 +12746,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -12749,7 +12756,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -12806,7 +12813,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -12816,7 +12823,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -12873,7 +12880,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -12883,7 +12890,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -12940,7 +12947,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -12950,7 +12957,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -13007,7 +13014,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -13017,7 +13024,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -13074,7 +13081,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -13084,7 +13091,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -13126,9 +13133,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00170--mixed3b-00179.jpg-->
-    
+
 
 
 
@@ -13313,7 +13320,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -13323,7 +13330,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -13380,7 +13387,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -13390,7 +13397,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -13447,7 +13454,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -13457,7 +13464,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -13514,7 +13521,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -13524,7 +13531,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -13581,7 +13588,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -13591,7 +13598,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -13648,7 +13655,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -13658,7 +13665,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -13715,7 +13722,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -13725,7 +13732,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -13782,7 +13789,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -13792,7 +13799,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -13849,7 +13856,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -13859,7 +13866,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -13916,7 +13923,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -13926,7 +13933,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -13968,9 +13975,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00180--mixed3b-00189.jpg-->
-    
+
 
 
 
@@ -14165,7 +14172,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -14175,7 +14182,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -14232,7 +14239,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -14242,7 +14249,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -14299,7 +14306,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -14309,7 +14316,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -14366,7 +14373,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -14376,7 +14383,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -14433,7 +14440,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -14443,7 +14450,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -14500,7 +14507,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -14510,7 +14517,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -14567,7 +14574,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -14577,7 +14584,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -14634,7 +14641,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -14644,7 +14651,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -14701,7 +14708,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -14711,7 +14718,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -14768,7 +14775,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -14778,7 +14785,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -14820,9 +14827,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00190--mixed3b-00199.jpg-->
-    
+
 
 
 
@@ -15027,7 +15034,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -15037,7 +15044,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -15094,7 +15101,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -15104,7 +15111,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -15161,7 +15168,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -15171,7 +15178,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -15228,7 +15235,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -15238,7 +15245,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -15295,7 +15302,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -15305,7 +15312,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -15362,7 +15369,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -15372,7 +15379,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -15429,7 +15436,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -15439,7 +15446,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -15496,7 +15503,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -15506,7 +15513,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -15563,7 +15570,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -15573,7 +15580,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -15630,7 +15637,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -15640,7 +15647,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -15682,9 +15689,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00200--mixed3b-00209.jpg-->
-    
+
 
 
 
@@ -15899,7 +15906,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -15909,7 +15916,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -15966,7 +15973,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -15976,7 +15983,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -16033,7 +16040,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -16043,7 +16050,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -16100,7 +16107,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -16110,7 +16117,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -16167,7 +16174,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -16177,7 +16184,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -16234,7 +16241,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -16244,7 +16251,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -16301,7 +16308,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -16311,7 +16318,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -16368,7 +16375,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -16378,7 +16385,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -16435,7 +16442,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -16445,7 +16452,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -16502,7 +16509,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -16512,7 +16519,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -16554,9 +16561,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00210--mixed3b-00219.jpg-->
-    
+
 
 
 
@@ -16781,7 +16788,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -16791,7 +16798,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -16848,7 +16855,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -16858,7 +16865,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -16915,7 +16922,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -16925,7 +16932,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -16982,7 +16989,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -16992,7 +16999,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -17049,7 +17056,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -17059,7 +17066,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -17116,7 +17123,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -17126,7 +17133,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -17183,7 +17190,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -17193,7 +17200,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -17250,7 +17257,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -17260,7 +17267,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -17317,7 +17324,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -17327,7 +17334,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -17384,7 +17391,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -17394,7 +17401,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -17436,9 +17443,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00220--mixed3b-00229.jpg-->
-    
+
 
 
 
@@ -17673,7 +17680,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -17683,7 +17690,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -17740,7 +17747,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -17750,7 +17757,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -17807,7 +17814,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -17817,7 +17824,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -17874,7 +17881,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -17884,7 +17891,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -17941,7 +17948,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -17951,7 +17958,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -18008,7 +18015,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -18018,7 +18025,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -18075,7 +18082,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -18085,7 +18092,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -18142,7 +18149,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -18152,7 +18159,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -18209,7 +18216,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -18219,7 +18226,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -18276,7 +18283,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -18286,7 +18293,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -18328,9 +18335,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00230--mixed3b-00239.jpg-->
-    
+
 
 
 
@@ -18575,7 +18582,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -18585,7 +18592,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -18642,7 +18649,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -18652,7 +18659,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -18709,7 +18716,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -18719,7 +18726,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -18776,7 +18783,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -18786,7 +18793,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -18843,7 +18850,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -18853,7 +18860,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -18910,7 +18917,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -18920,7 +18927,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -18977,7 +18984,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -18987,7 +18994,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -19044,7 +19051,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -19054,7 +19061,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -19111,7 +19118,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -19121,7 +19128,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -19178,7 +19185,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -19188,7 +19195,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -19230,9 +19237,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00240--mixed3b-00249.jpg-->
-    
+
 
 
 
@@ -19487,7 +19494,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -19497,7 +19504,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -19554,7 +19561,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -19564,7 +19571,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -19621,7 +19628,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -19631,7 +19638,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -19688,7 +19695,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -19698,7 +19705,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -19755,7 +19762,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -19765,7 +19772,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -19822,7 +19829,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -19832,7 +19839,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -19889,7 +19896,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -19899,7 +19906,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -19956,7 +19963,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -19966,7 +19973,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -20023,7 +20030,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -20033,7 +20040,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -20090,7 +20097,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -20100,7 +20107,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -20142,9 +20149,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00250--mixed3b-00259.jpg-->
-    
+
 
 
 
@@ -20409,7 +20416,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -20419,7 +20426,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -20476,7 +20483,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -20486,7 +20493,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -20543,7 +20550,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -20553,7 +20560,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -20610,7 +20617,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -20620,7 +20627,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -20677,7 +20684,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -20687,7 +20694,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -20744,7 +20751,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -20754,7 +20761,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -20811,7 +20818,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -20821,7 +20828,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -20878,7 +20885,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -20888,7 +20895,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -20945,7 +20952,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -20955,7 +20962,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -21012,7 +21019,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -21022,7 +21029,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -21064,9 +21071,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00260--mixed3b-00269.jpg-->
-    
+
 
 
 
@@ -21341,7 +21348,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -21351,7 +21358,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -21408,7 +21415,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -21418,7 +21425,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -21475,7 +21482,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -21485,7 +21492,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -21542,7 +21549,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -21552,7 +21559,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -21609,7 +21616,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -21619,7 +21626,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -21676,7 +21683,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -21686,7 +21693,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -21743,7 +21750,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -21753,7 +21760,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -21810,7 +21817,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -21820,7 +21827,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -21877,7 +21884,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -21887,7 +21894,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -21944,7 +21951,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -21954,7 +21961,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -21996,9 +22003,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00270--mixed3b-00279.jpg-->
-    
+
 
 
 
@@ -22283,7 +22290,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -22293,7 +22300,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -22350,7 +22357,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -22360,7 +22367,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -22417,7 +22424,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -22427,7 +22434,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -22484,7 +22491,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -22494,7 +22501,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -22551,7 +22558,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -22561,7 +22568,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -22618,7 +22625,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -22628,7 +22635,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -22685,7 +22692,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -22695,7 +22702,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -22752,7 +22759,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -22762,7 +22769,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -22819,7 +22826,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -22829,7 +22836,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -22886,7 +22893,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -22896,7 +22903,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -22938,9 +22945,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00280--mixed3b-00289.jpg-->
-    
+
 
 
 
@@ -23235,7 +23242,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -23245,7 +23252,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -23302,7 +23309,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -23312,7 +23319,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -23369,7 +23376,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -23379,7 +23386,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -23436,7 +23443,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -23446,7 +23453,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -23503,7 +23510,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -23513,7 +23520,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -23570,7 +23577,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -23580,7 +23587,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -23637,7 +23644,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -23647,7 +23654,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -23704,7 +23711,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -23714,7 +23721,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -23771,7 +23778,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -23781,7 +23788,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -23838,7 +23845,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -23848,7 +23855,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -23890,9 +23897,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00290--mixed3b-00299.jpg-->
-    
+
 
 
 
@@ -24197,7 +24204,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -24207,7 +24214,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -24264,7 +24271,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -24274,7 +24281,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -24331,7 +24338,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -24341,7 +24348,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -24398,7 +24405,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -24408,7 +24415,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -24465,7 +24472,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -24475,7 +24482,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -24532,7 +24539,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -24542,7 +24549,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -24599,7 +24606,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -24609,7 +24616,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -24666,7 +24673,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -24676,7 +24683,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -24733,7 +24740,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -24743,7 +24750,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -24800,7 +24807,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -24810,7 +24817,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -24852,9 +24859,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00300--mixed3b-00309.jpg-->
-    
+
 
 
 
@@ -25169,7 +25176,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -25179,7 +25186,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -25236,7 +25243,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -25246,7 +25253,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -25303,7 +25310,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -25313,7 +25320,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -25370,7 +25377,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -25380,7 +25387,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -25437,7 +25444,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -25447,7 +25454,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -25504,7 +25511,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -25514,7 +25521,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -25571,7 +25578,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -25581,7 +25588,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -25638,7 +25645,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -25648,7 +25655,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -25705,7 +25712,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -25715,7 +25722,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -25772,7 +25779,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -25782,7 +25789,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -25824,9 +25831,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00310--mixed3b-00319.jpg-->
-    
+
 
 
 
@@ -26151,7 +26158,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -26161,7 +26168,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -26218,7 +26225,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -26228,7 +26235,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -26285,7 +26292,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -26295,7 +26302,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -26352,7 +26359,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -26362,7 +26369,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -26419,7 +26426,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -26429,7 +26436,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -26486,7 +26493,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -26496,7 +26503,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -26553,7 +26560,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -26563,7 +26570,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -26620,7 +26627,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -26630,7 +26637,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -26687,7 +26694,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -26697,7 +26704,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -26754,7 +26761,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -26764,7 +26771,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -26806,9 +26813,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00320--mixed3b-00329.jpg-->
-    
+
 
 
 
@@ -27143,7 +27150,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -27153,7 +27160,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -27210,7 +27217,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -27220,7 +27227,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -27277,7 +27284,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -27287,7 +27294,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -27344,7 +27351,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -27354,7 +27361,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -27411,7 +27418,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -27421,7 +27428,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -27478,7 +27485,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -27488,7 +27495,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -27545,7 +27552,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -27555,7 +27562,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -27612,7 +27619,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -27622,7 +27629,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -27679,7 +27686,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -27689,7 +27696,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -27746,7 +27753,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -27756,7 +27763,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -27798,9 +27805,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00330--mixed3b-00339.jpg-->
-    
+
 
 
 
@@ -28145,7 +28152,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -28155,7 +28162,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -28212,7 +28219,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -28222,7 +28229,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -28279,7 +28286,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -28289,7 +28296,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -28346,7 +28353,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -28356,7 +28363,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -28413,7 +28420,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -28423,7 +28430,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -28480,7 +28487,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -28490,7 +28497,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -28547,7 +28554,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -28557,7 +28564,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -28614,7 +28621,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -28624,7 +28631,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -28681,7 +28688,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -28691,7 +28698,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -28748,7 +28755,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -28758,7 +28765,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -28800,9 +28807,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00340--mixed3b-00349.jpg-->
-    
+
 
 
 
@@ -29157,7 +29164,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -29167,7 +29174,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -29224,7 +29231,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -29234,7 +29241,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -29291,7 +29298,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -29301,7 +29308,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -29358,7 +29365,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -29368,7 +29375,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -29425,7 +29432,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -29435,7 +29442,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -29492,7 +29499,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -29502,7 +29509,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -29559,7 +29566,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -29569,7 +29576,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -29626,7 +29633,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -29636,7 +29643,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -29693,7 +29700,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -29703,7 +29710,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -29760,7 +29767,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -29770,7 +29777,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -29812,9 +29819,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00350--mixed3b-00359.jpg-->
-    
+
 
 
 
@@ -30179,7 +30186,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -30189,7 +30196,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -30246,7 +30253,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -30256,7 +30263,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -30313,7 +30320,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -30323,7 +30330,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -30380,7 +30387,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -30390,7 +30397,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -30447,7 +30454,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -30457,7 +30464,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -30514,7 +30521,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -30524,7 +30531,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -30581,7 +30588,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -30591,7 +30598,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -30648,7 +30655,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -30658,7 +30665,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -30715,7 +30722,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -30725,7 +30732,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -30782,7 +30789,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -30792,7 +30799,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -30834,9 +30841,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00360--mixed3b-00369.jpg-->
-    
+
 
 
 
@@ -31211,7 +31218,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -31221,7 +31228,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -31278,7 +31285,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -31288,7 +31295,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -31345,7 +31352,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -31355,7 +31362,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -31412,7 +31419,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -31422,7 +31429,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -31479,7 +31486,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -31489,7 +31496,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -31546,7 +31553,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -31556,7 +31563,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -31613,7 +31620,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -31623,7 +31630,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -31680,7 +31687,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -31690,7 +31697,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -31747,7 +31754,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -31757,7 +31764,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -31814,7 +31821,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -31824,7 +31831,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -31866,9 +31873,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00370--mixed3b-00379.jpg-->
-    
+
 
 
 
@@ -32253,7 +32260,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -32263,7 +32270,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -32320,7 +32327,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -32330,7 +32337,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -32387,7 +32394,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -32397,7 +32404,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -32454,7 +32461,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -32464,7 +32471,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -32521,7 +32528,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -32531,7 +32538,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -32588,7 +32595,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -32598,7 +32605,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -32655,7 +32662,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -32665,7 +32672,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -32722,7 +32729,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -32732,7 +32739,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -32789,7 +32796,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -32799,7 +32806,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -32856,7 +32863,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -32866,7 +32873,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -32908,9 +32915,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00380--mixed3b-00389.jpg-->
-    
+
 
 
 
@@ -33305,7 +33312,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -33315,7 +33322,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -33372,7 +33379,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -33382,7 +33389,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -33439,7 +33446,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -33449,7 +33456,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -33506,7 +33513,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -33516,7 +33523,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -33573,7 +33580,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -33583,7 +33590,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -33640,7 +33647,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -33650,7 +33657,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -33707,7 +33714,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -33717,7 +33724,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -33774,7 +33781,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -33784,7 +33791,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -33841,7 +33848,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -33851,7 +33858,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -33908,7 +33915,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -33918,7 +33925,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -33960,9 +33967,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00390--mixed3b-00399.jpg-->
-    
+
 
 
 
@@ -34367,7 +34374,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -34377,7 +34384,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -34434,7 +34441,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -34444,7 +34451,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -34501,7 +34508,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -34511,7 +34518,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -34568,7 +34575,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -34578,7 +34585,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -34635,7 +34642,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -34645,7 +34652,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -34702,7 +34709,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -34712,7 +34719,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -34769,7 +34776,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -34779,7 +34786,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -34836,7 +34843,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -34846,7 +34853,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -34903,7 +34910,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -34913,7 +34920,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -34970,7 +34977,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -34980,7 +34987,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -35022,9 +35029,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00400--mixed3b-00409.jpg-->
-    
+
 
 
 
@@ -35439,7 +35446,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -35449,7 +35456,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -35506,7 +35513,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -35516,7 +35523,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -35573,7 +35580,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -35583,7 +35590,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -35640,7 +35647,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -35650,7 +35657,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -35707,7 +35714,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -35717,7 +35724,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -35774,7 +35781,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -35784,7 +35791,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -35841,7 +35848,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -35851,7 +35858,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -35908,7 +35915,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -35918,7 +35925,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -35975,7 +35982,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -35985,7 +35992,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -36042,7 +36049,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -36052,7 +36059,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -36094,9 +36101,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00410--mixed3b-00419.jpg-->
-    
+
 
 
 
@@ -36521,7 +36528,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -36531,7 +36538,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -36588,7 +36595,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -36598,7 +36605,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -36655,7 +36662,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -36665,7 +36672,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -36722,7 +36729,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -36732,7 +36739,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -36789,7 +36796,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -36799,7 +36806,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -36856,7 +36863,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -36866,7 +36873,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -36923,7 +36930,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -36933,7 +36940,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -36990,7 +36997,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -37000,7 +37007,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -37057,7 +37064,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -37067,7 +37074,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -37124,7 +37131,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -37134,7 +37141,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -37176,9 +37183,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00420--mixed3b-00429.jpg-->
-    
+
 
 
 
@@ -37613,7 +37620,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -37623,7 +37630,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -37680,7 +37687,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -37690,7 +37697,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -37747,7 +37754,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -37757,7 +37764,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -37814,7 +37821,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -37824,7 +37831,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -37881,7 +37888,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -37891,7 +37898,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -37948,7 +37955,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -37958,7 +37965,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -38015,7 +38022,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -38025,7 +38032,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -38082,7 +38089,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -38092,7 +38099,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -38149,7 +38156,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -38159,7 +38166,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -38216,7 +38223,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -38226,7 +38233,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -38268,9 +38275,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00430--mixed3b-00439.jpg-->
-    
+
 
 
 
@@ -38715,7 +38722,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -38725,7 +38732,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -38782,7 +38789,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -38792,7 +38799,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -38849,7 +38856,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -38859,7 +38866,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -38916,7 +38923,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -38926,7 +38933,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -38983,7 +38990,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -38993,7 +39000,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -39050,7 +39057,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -39060,7 +39067,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -39117,7 +39124,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -39127,7 +39134,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -39184,7 +39191,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -39194,7 +39201,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -39251,7 +39258,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -39261,7 +39268,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -39318,7 +39325,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -39328,7 +39335,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -39370,9 +39377,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00440--mixed3b-00449.jpg-->
-    
+
 
 
 
@@ -39827,7 +39834,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -39837,7 +39844,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -39894,7 +39901,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -39904,7 +39911,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -39961,7 +39968,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -39971,7 +39978,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -40028,7 +40035,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -40038,7 +40045,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -40095,7 +40102,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -40105,7 +40112,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -40162,7 +40169,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -40172,7 +40179,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -40229,7 +40236,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -40239,7 +40246,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -40296,7 +40303,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -40306,7 +40313,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -40363,7 +40370,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -40373,7 +40380,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -40430,7 +40437,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -40440,7 +40447,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -40482,9 +40489,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00450--mixed3b-00459.jpg-->
-    
+
 
 
 
@@ -40949,7 +40956,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -40959,7 +40966,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -41016,7 +41023,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -41026,7 +41033,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -41083,7 +41090,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -41093,7 +41100,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -41150,7 +41157,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -41160,7 +41167,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -41217,7 +41224,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -41227,7 +41234,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -41284,7 +41291,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -41294,7 +41301,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -41351,7 +41358,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -41361,7 +41368,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -41418,7 +41425,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -41428,7 +41435,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -41485,7 +41492,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -41495,7 +41502,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -41552,7 +41559,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -41562,7 +41569,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -41604,9 +41611,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00460--mixed3b-00469.jpg-->
-    
+
 
 
 
@@ -42081,7 +42088,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -42091,7 +42098,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -42148,7 +42155,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -42158,7 +42165,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -42215,7 +42222,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -42225,7 +42232,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -42282,7 +42289,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -42292,7 +42299,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -42349,7 +42356,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -42359,7 +42366,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -42416,7 +42423,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -42426,7 +42433,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -42483,7 +42490,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -42493,7 +42500,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -42550,7 +42557,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -42560,7 +42567,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -42617,7 +42624,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -42627,7 +42634,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -42684,7 +42691,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -42694,7 +42701,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -42736,9 +42743,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed3b-00470--mixed3b-00479.jpg-->
-    
+
 
 
 
@@ -43223,7 +43230,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -43233,7 +43240,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -43290,7 +43297,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -43300,7 +43307,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -43357,7 +43364,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -43367,7 +43374,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -43424,7 +43431,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -43434,7 +43441,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -43491,7 +43498,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -43501,7 +43508,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -43558,7 +43565,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -43568,7 +43575,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -43625,7 +43632,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -43635,7 +43642,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -43692,7 +43699,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -43702,7 +43709,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -43759,7 +43766,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -43769,7 +43776,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -43826,7 +43833,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -43836,7 +43843,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -43878,9 +43885,8 @@
       </div>
       </d-figure>
       </li>
-  
+
   </ul>
   </d-article>
   <distill-footer></distill-footer>
 </body>
-  

--- a/public/appendix/googlenet/4a.html
+++ b/public/appendix/googlenet/4a.html
@@ -5,21 +5,21 @@
   <meta charset="utf8">
   <script src="https://distill.pub/template.v2.js"></script>
   <style>
-  
+
     d-article {
       line-height: 1em;
     }
-    
+
     d-byline,
     d-appendix {
       display: none;
     }
-  
+
     h4 {
       display: block;
       width: 100%;
     }
-    
+
     d-figure {
       display: flex;
       flex-flow: row;
@@ -31,7 +31,7 @@
       margin-bottom: 1em;
       justify-content: center;
     }
-    
+
     .positive,
     .negative {
       display: flex;
@@ -40,7 +40,7 @@
       align-content: flex-start;
       max-width: 370px;
     }
-    
+
     .positive {
       padding-left: 1em;
       padding-right: 1em;
@@ -50,14 +50,14 @@
       border-right: 1px solid rgba(0,0,0,0.1);
       justify-content: space-between;
     }
-    
+
     .figcaption {
       display: block;
       color: rgba(0, 0, 0, 0.6);
       font-size: 12px;
       line-height: 1.5em;
     }
-    
+
     .diversity {
       display: flex;
       flex-flow: row;
@@ -65,61 +65,61 @@
       width: 148px;
       height: 147px
     }
-    
+
     .diversity > div {
       zoom: 0.496598639;
     }
-    
+
     .channel {
       margin-right: 1em;
     }
-    
+
     .channels {
       grid-column: screen;
       list-style: none;
       padding-left: 0;
     }
-    
+
     .channels li {
       contain: content;
       overflow: hidden;
     }
-    
+
     .sprite {
       display: inline-block;
       margin: 1px;
       width: 147px;
       height: 147px;
     }
-    
+
     .sprite.neuron {
       background-position-x: 0px;
     }
-    
+
     .sprite.channel {
       background-position-x: -147px;
     }
-    
+
     .sprite.channel-negative {
       background-position-x: -294px;
     }
-    
+
     .sprite.channel-diversity-0 {
       background-position-x: -441px;
     }
-    
+
     .sprite.channel-diversity-1 {
       background-position-x: -588px;
     }
-    
+
     .sprite.channel-diversity-2 {
       background-position-x: -735px;
     }
-    
+
     .sprite.channel-diversity-3 {
       background-position-x: -882px;
     }
-    
+
     .dataset-examples {
       display: flex;
       flex-flow: row;
@@ -127,7 +127,7 @@
       width: 375px;
       height: 147px
     }
-    
+
     .dataset-examples .sprite {
       height: 73px;
       width: 73px;
@@ -136,16 +136,16 @@
       margin-bottom: 0;
       margin-right: 0;
     }
-    
-    
+
+
       .channels .sprite.dataset-index-0 {
         background-position-x: -1029px !important;
       }
-      
+
       .channels .sprite.index-0 {
         background-position-y: -0px;
       }
-      
+
       .channels .dataset-negative .sprite.index-0 {
         background-position-y: -74px !important;
       }
@@ -153,11 +153,11 @@
       .channels .sprite.dataset-index-1 {
         background-position-x: -1103px !important;
       }
-      
+
       .channels .sprite.index-1 {
         background-position-y: -147px;
       }
-      
+
       .channels .dataset-negative .sprite.index-1 {
         background-position-y: -221px !important;
       }
@@ -165,11 +165,11 @@
       .channels .sprite.dataset-index-2 {
         background-position-x: -1177px !important;
       }
-      
+
       .channels .sprite.index-2 {
         background-position-y: -294px;
       }
-      
+
       .channels .dataset-negative .sprite.index-2 {
         background-position-y: -368px !important;
       }
@@ -177,11 +177,11 @@
       .channels .sprite.dataset-index-3 {
         background-position-x: -1251px !important;
       }
-      
+
       .channels .sprite.index-3 {
         background-position-y: -441px;
       }
-      
+
       .channels .dataset-negative .sprite.index-3 {
         background-position-y: -515px !important;
       }
@@ -189,11 +189,11 @@
       .channels .sprite.dataset-index-4 {
         background-position-x: -1325px !important;
       }
-      
+
       .channels .sprite.index-4 {
         background-position-y: -588px;
       }
-      
+
       .channels .dataset-negative .sprite.index-4 {
         background-position-y: -662px !important;
       }
@@ -201,11 +201,11 @@
       .channels .sprite.dataset-index-5 {
         background-position-x: -1399px !important;
       }
-      
+
       .channels .sprite.index-5 {
         background-position-y: -735px;
       }
-      
+
       .channels .dataset-negative .sprite.index-5 {
         background-position-y: -809px !important;
       }
@@ -213,11 +213,11 @@
       .channels .sprite.dataset-index-6 {
         background-position-x: -1473px !important;
       }
-      
+
       .channels .sprite.index-6 {
         background-position-y: -882px;
       }
-      
+
       .channels .dataset-negative .sprite.index-6 {
         background-position-y: -956px !important;
       }
@@ -225,11 +225,11 @@
       .channels .sprite.dataset-index-7 {
         background-position-x: -1547px !important;
       }
-      
+
       .channels .sprite.index-7 {
         background-position-y: -1029px;
       }
-      
+
       .channels .dataset-negative .sprite.index-7 {
         background-position-y: -1103px !important;
       }
@@ -237,11 +237,11 @@
       .channels .sprite.dataset-index-8 {
         background-position-x: -1621px !important;
       }
-      
+
       .channels .sprite.index-8 {
         background-position-y: -1176px;
       }
-      
+
       .channels .dataset-negative .sprite.index-8 {
         background-position-y: -1250px !important;
       }
@@ -249,20 +249,20 @@
       .channels .sprite.dataset-index-9 {
         background-position-x: -1695px !important;
       }
-      
+
       .channels .sprite.index-9 {
         background-position-y: -1323px;
       }
-      
+
       .channels .dataset-negative .sprite.index-9 {
         background-position-y: -1397px !important;
       }
-    
-    
+
+
     .article-nav {
       grid-column: page;
     }
-    
+
     .navlist li {
       display: inline;
       list-style-type: none;
@@ -300,10 +300,10 @@
     <h1>Layer 4a</h1>
   </d-title>
   <d-article>
-  
+
   <nav class="article-nav">
-  
-    
+
+
     <ul class="navlist">
       <li><a href="https://distill.pub/2017/feature-visualization/appendix/">Appendix overview</a></li>
       <li><a href="https://distill.pub/2017/feature-visualization/">Main article</a></li>
@@ -316,7 +316,7 @@
         <a href="3b.html">Layer 3b</a>
       </li>
       <li>
-        <a href="4a.html">Layer 4a</a>
+        <a href="4a.html"><b>Layer 4a</b></a>
       </li>
       <li>
         <a href="4b.html">Layer 4b</a>
@@ -337,14 +337,21 @@
         <a href="5b.html">Layer 5b</a>
       </li>
     </ul>
-  
+
+    <ul class="navlist">
+      <li> <a href="4a.html#4a-0">4a 1x1</a> <span style="color: #777;">(0:192)</span> </li>
+      <li> <a href="4a.html#4a-192">4a 3x3</a> <span style="color: #777;">(192:396)</span> </li>
+      <li> <a href="4a.html#4a-396">4a 5x5</a> <span style="color: #777;">(396:444)</span> </li>
+      <li> <a href="4a.html#4a-444">4a pool</a> <span style="color: #777;">(444:508)</span> </li>
+    </ul>
+
   </nav>
-  
+
   <hr style="margin-top: 20px;"/>
-  
+
   <ul class="channels">
     <!--mixed4a-00000--mixed4a-00009.jpg-->
-    
+
       <li id="channel-0">
       <d-figure id="4a-0">
       <style data-img-src="images/mixed4a-00000--mixed4a-00009.jpg" data-channel="0"></style>
@@ -359,7 +366,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -369,7 +376,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -426,7 +433,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -436,7 +443,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -493,7 +500,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -503,7 +510,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -560,7 +567,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -570,7 +577,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -627,7 +634,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -637,7 +644,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -694,7 +701,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -704,7 +711,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -761,7 +768,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -771,7 +778,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -828,7 +835,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -838,7 +845,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -895,7 +902,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -905,7 +912,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -962,7 +969,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -972,7 +979,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -1014,9 +1021,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00010--mixed4a-00019.jpg-->
-    
+
 
 
 
@@ -1041,7 +1048,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -1051,7 +1058,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -1108,7 +1115,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -1118,7 +1125,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -1175,7 +1182,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -1185,7 +1192,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -1242,7 +1249,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -1252,7 +1259,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -1309,7 +1316,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -1319,7 +1326,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -1376,7 +1383,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -1386,7 +1393,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -1443,7 +1450,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -1453,7 +1460,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -1510,7 +1517,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -1520,7 +1527,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -1577,7 +1584,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -1587,7 +1594,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -1644,7 +1651,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -1654,7 +1661,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -1696,9 +1703,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00020--mixed4a-00029.jpg-->
-    
+
 
 
 
@@ -1733,7 +1740,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -1743,7 +1750,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -1800,7 +1807,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -1810,7 +1817,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -1867,7 +1874,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -1877,7 +1884,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -1934,7 +1941,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -1944,7 +1951,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -2001,7 +2008,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -2011,7 +2018,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -2068,7 +2075,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -2078,7 +2085,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -2135,7 +2142,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -2145,7 +2152,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -2202,7 +2209,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -2212,7 +2219,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -2269,7 +2276,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -2279,7 +2286,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -2336,7 +2343,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -2346,7 +2353,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -2388,9 +2395,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00030--mixed4a-00039.jpg-->
-    
+
 
 
 
@@ -2435,7 +2442,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -2445,7 +2452,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -2502,7 +2509,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -2512,7 +2519,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -2569,7 +2576,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -2579,7 +2586,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -2636,7 +2643,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -2646,7 +2653,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -2703,7 +2710,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -2713,7 +2720,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -2770,7 +2777,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -2780,7 +2787,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -2837,7 +2844,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -2847,7 +2854,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -2904,7 +2911,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -2914,7 +2921,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -2971,7 +2978,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -2981,7 +2988,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -3038,7 +3045,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -3048,7 +3055,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -3090,9 +3097,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00040--mixed4a-00049.jpg-->
-    
+
 
 
 
@@ -3147,7 +3154,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -3157,7 +3164,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -3214,7 +3221,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -3224,7 +3231,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -3281,7 +3288,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -3291,7 +3298,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -3348,7 +3355,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -3358,7 +3365,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -3415,7 +3422,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -3425,7 +3432,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -3482,7 +3489,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -3492,7 +3499,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -3549,7 +3556,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -3559,7 +3566,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -3616,7 +3623,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -3626,7 +3633,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -3683,7 +3690,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -3693,7 +3700,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -3750,7 +3757,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -3760,7 +3767,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -3802,9 +3809,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00050--mixed4a-00059.jpg-->
-    
+
 
 
 
@@ -3869,7 +3876,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -3879,7 +3886,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -3936,7 +3943,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -3946,7 +3953,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -4003,7 +4010,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -4013,7 +4020,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -4070,7 +4077,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -4080,7 +4087,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -4137,7 +4144,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -4147,7 +4154,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -4204,7 +4211,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -4214,7 +4221,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -4271,7 +4278,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -4281,7 +4288,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -4338,7 +4345,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -4348,7 +4355,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -4405,7 +4412,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -4415,7 +4422,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -4472,7 +4479,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -4482,7 +4489,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -4524,9 +4531,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00060--mixed4a-00069.jpg-->
-    
+
 
 
 
@@ -4601,7 +4608,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -4611,7 +4618,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -4668,7 +4675,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -4678,7 +4685,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -4735,7 +4742,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -4745,7 +4752,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -4802,7 +4809,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -4812,7 +4819,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -4869,7 +4876,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -4879,7 +4886,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -4936,7 +4943,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -4946,7 +4953,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -5003,7 +5010,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -5013,7 +5020,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -5070,7 +5077,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -5080,7 +5087,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -5137,7 +5144,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -5147,7 +5154,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -5204,7 +5211,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -5214,7 +5221,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -5256,9 +5263,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00070--mixed4a-00079.jpg-->
-    
+
 
 
 
@@ -5343,7 +5350,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -5353,7 +5360,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -5410,7 +5417,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -5420,7 +5427,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -5477,7 +5484,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -5487,7 +5494,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -5544,7 +5551,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -5554,7 +5561,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -5611,7 +5618,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -5621,7 +5628,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -5678,7 +5685,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -5688,7 +5695,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -5745,7 +5752,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -5755,7 +5762,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -5812,7 +5819,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -5822,7 +5829,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -5879,7 +5886,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -5889,7 +5896,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -5946,7 +5953,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -5956,7 +5963,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -5998,9 +6005,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00080--mixed4a-00089.jpg-->
-    
+
 
 
 
@@ -6095,7 +6102,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -6105,7 +6112,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -6162,7 +6169,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -6172,7 +6179,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -6229,7 +6236,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -6239,7 +6246,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -6296,7 +6303,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -6306,7 +6313,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -6363,7 +6370,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -6373,7 +6380,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -6430,7 +6437,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -6440,7 +6447,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -6497,7 +6504,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -6507,7 +6514,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -6564,7 +6571,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -6574,7 +6581,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -6631,7 +6638,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -6641,7 +6648,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -6698,7 +6705,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -6708,7 +6715,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -6750,9 +6757,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00090--mixed4a-00099.jpg-->
-    
+
 
 
 
@@ -6857,7 +6864,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -6867,7 +6874,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -6924,7 +6931,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -6934,7 +6941,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -6991,7 +6998,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -7001,7 +7008,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -7058,7 +7065,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -7068,7 +7075,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -7125,7 +7132,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -7135,7 +7142,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -7192,7 +7199,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -7202,7 +7209,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -7259,7 +7266,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -7269,7 +7276,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -7326,7 +7333,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -7336,7 +7343,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -7393,7 +7400,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -7403,7 +7410,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -7460,7 +7467,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -7470,7 +7477,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -7512,9 +7519,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00100--mixed4a-00109.jpg-->
-    
+
 
 
 
@@ -7629,7 +7636,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -7639,7 +7646,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -7696,7 +7703,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -7706,7 +7713,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -7763,7 +7770,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -7773,7 +7780,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -7830,7 +7837,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -7840,7 +7847,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -7897,7 +7904,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -7907,7 +7914,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -7964,7 +7971,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -7974,7 +7981,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -8031,7 +8038,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -8041,7 +8048,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -8098,7 +8105,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -8108,7 +8115,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -8165,7 +8172,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -8175,7 +8182,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -8232,7 +8239,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -8242,7 +8249,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -8284,9 +8291,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00110--mixed4a-00119.jpg-->
-    
+
 
 
 
@@ -8411,7 +8418,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -8421,7 +8428,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -8478,7 +8485,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -8488,7 +8495,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -8545,7 +8552,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -8555,7 +8562,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -8612,7 +8619,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -8622,7 +8629,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -8679,7 +8686,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -8689,7 +8696,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -8746,7 +8753,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -8756,7 +8763,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -8813,7 +8820,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -8823,7 +8830,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -8880,7 +8887,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -8890,7 +8897,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -8947,7 +8954,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -8957,7 +8964,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -9014,7 +9021,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -9024,7 +9031,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -9066,9 +9073,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00120--mixed4a-00129.jpg-->
-    
+
 
 
 
@@ -9203,7 +9210,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -9213,7 +9220,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -9270,7 +9277,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -9280,7 +9287,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -9337,7 +9344,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -9347,7 +9354,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -9404,7 +9411,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -9414,7 +9421,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -9471,7 +9478,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -9481,7 +9488,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -9538,7 +9545,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -9548,7 +9555,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -9605,7 +9612,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -9615,7 +9622,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -9672,7 +9679,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -9682,7 +9689,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -9739,7 +9746,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -9749,7 +9756,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -9806,7 +9813,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -9816,7 +9823,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -9858,9 +9865,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00130--mixed4a-00139.jpg-->
-    
+
 
 
 
@@ -10005,7 +10012,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -10015,7 +10022,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -10072,7 +10079,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -10082,7 +10089,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -10139,7 +10146,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -10149,7 +10156,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -10206,7 +10213,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -10216,7 +10223,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -10273,7 +10280,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -10283,7 +10290,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -10340,7 +10347,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -10350,7 +10357,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -10407,7 +10414,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -10417,7 +10424,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -10474,7 +10481,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -10484,7 +10491,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -10541,7 +10548,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -10551,7 +10558,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -10608,7 +10615,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -10618,7 +10625,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -10660,9 +10667,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00140--mixed4a-00149.jpg-->
-    
+
 
 
 
@@ -10817,7 +10824,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -10827,7 +10834,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -10884,7 +10891,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -10894,7 +10901,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -10951,7 +10958,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -10961,7 +10968,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -11018,7 +11025,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -11028,7 +11035,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -11085,7 +11092,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -11095,7 +11102,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -11152,7 +11159,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -11162,7 +11169,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -11219,7 +11226,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -11229,7 +11236,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -11286,7 +11293,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -11296,7 +11303,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -11353,7 +11360,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -11363,7 +11370,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -11420,7 +11427,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -11430,7 +11437,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -11472,9 +11479,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00150--mixed4a-00159.jpg-->
-    
+
 
 
 
@@ -11639,7 +11646,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -11649,7 +11656,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -11706,7 +11713,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -11716,7 +11723,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -11773,7 +11780,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -11783,7 +11790,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -11840,7 +11847,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -11850,7 +11857,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -11907,7 +11914,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -11917,7 +11924,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -11974,7 +11981,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -11984,7 +11991,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -12041,7 +12048,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -12051,7 +12058,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -12108,7 +12115,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -12118,7 +12125,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -12175,7 +12182,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -12185,7 +12192,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -12242,7 +12249,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -12252,7 +12259,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -12294,9 +12301,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00160--mixed4a-00169.jpg-->
-    
+
 
 
 
@@ -12471,7 +12478,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -12481,7 +12488,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -12538,7 +12545,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -12548,7 +12555,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -12605,7 +12612,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -12615,7 +12622,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -12672,7 +12679,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -12682,7 +12689,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -12739,7 +12746,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -12749,7 +12756,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -12806,7 +12813,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -12816,7 +12823,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -12873,7 +12880,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -12883,7 +12890,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -12940,7 +12947,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -12950,7 +12957,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -13007,7 +13014,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -13017,7 +13024,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -13074,7 +13081,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -13084,7 +13091,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -13126,9 +13133,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00170--mixed4a-00179.jpg-->
-    
+
 
 
 
@@ -13313,7 +13320,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -13323,7 +13330,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -13380,7 +13387,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -13390,7 +13397,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -13447,7 +13454,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -13457,7 +13464,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -13514,7 +13521,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -13524,7 +13531,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -13581,7 +13588,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -13591,7 +13598,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -13648,7 +13655,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -13658,7 +13665,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -13715,7 +13722,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -13725,7 +13732,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -13782,7 +13789,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -13792,7 +13799,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -13849,7 +13856,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -13859,7 +13866,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -13916,7 +13923,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -13926,7 +13933,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -13968,9 +13975,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00180--mixed4a-00189.jpg-->
-    
+
 
 
 
@@ -14165,7 +14172,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -14175,7 +14182,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -14232,7 +14239,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -14242,7 +14249,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -14299,7 +14306,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -14309,7 +14316,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -14366,7 +14373,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -14376,7 +14383,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -14433,7 +14440,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -14443,7 +14450,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -14500,7 +14507,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -14510,7 +14517,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -14567,7 +14574,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -14577,7 +14584,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -14634,7 +14641,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -14644,7 +14651,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -14701,7 +14708,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -14711,7 +14718,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -14768,7 +14775,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -14778,7 +14785,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -14820,9 +14827,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00190--mixed4a-00199.jpg-->
-    
+
 
 
 
@@ -15027,7 +15034,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -15037,7 +15044,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -15094,7 +15101,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -15104,7 +15111,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -15161,7 +15168,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -15171,7 +15178,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -15228,7 +15235,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -15238,7 +15245,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -15295,7 +15302,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -15305,7 +15312,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -15362,7 +15369,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -15372,7 +15379,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -15429,7 +15436,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -15439,7 +15446,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -15496,7 +15503,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -15506,7 +15513,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -15563,7 +15570,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -15573,7 +15580,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -15630,7 +15637,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -15640,7 +15647,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -15682,9 +15689,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00200--mixed4a-00209.jpg-->
-    
+
 
 
 
@@ -15899,7 +15906,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -15909,7 +15916,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -15966,7 +15973,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -15976,7 +15983,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -16033,7 +16040,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -16043,7 +16050,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -16100,7 +16107,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -16110,7 +16117,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -16167,7 +16174,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -16177,7 +16184,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -16234,7 +16241,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -16244,7 +16251,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -16301,7 +16308,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -16311,7 +16318,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -16368,7 +16375,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -16378,7 +16385,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -16435,7 +16442,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -16445,7 +16452,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -16502,7 +16509,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -16512,7 +16519,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -16554,9 +16561,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00210--mixed4a-00219.jpg-->
-    
+
 
 
 
@@ -16781,7 +16788,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -16791,7 +16798,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -16848,7 +16855,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -16858,7 +16865,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -16915,7 +16922,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -16925,7 +16932,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -16982,7 +16989,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -16992,7 +16999,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -17049,7 +17056,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -17059,7 +17066,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -17116,7 +17123,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -17126,7 +17133,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -17183,7 +17190,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -17193,7 +17200,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -17250,7 +17257,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -17260,7 +17267,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -17317,7 +17324,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -17327,7 +17334,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -17384,7 +17391,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -17394,7 +17401,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -17436,9 +17443,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00220--mixed4a-00229.jpg-->
-    
+
 
 
 
@@ -17673,7 +17680,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -17683,7 +17690,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -17740,7 +17747,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -17750,7 +17757,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -17807,7 +17814,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -17817,7 +17824,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -17874,7 +17881,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -17884,7 +17891,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -17941,7 +17948,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -17951,7 +17958,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -18008,7 +18015,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -18018,7 +18025,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -18075,7 +18082,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -18085,7 +18092,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -18142,7 +18149,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -18152,7 +18159,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -18209,7 +18216,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -18219,7 +18226,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -18276,7 +18283,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -18286,7 +18293,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -18328,9 +18335,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00230--mixed4a-00239.jpg-->
-    
+
 
 
 
@@ -18575,7 +18582,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -18585,7 +18592,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -18642,7 +18649,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -18652,7 +18659,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -18709,7 +18716,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -18719,7 +18726,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -18776,7 +18783,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -18786,7 +18793,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -18843,7 +18850,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -18853,7 +18860,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -18910,7 +18917,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -18920,7 +18927,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -18977,7 +18984,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -18987,7 +18994,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -19044,7 +19051,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -19054,7 +19061,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -19111,7 +19118,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -19121,7 +19128,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -19178,7 +19185,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -19188,7 +19195,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -19230,9 +19237,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00240--mixed4a-00249.jpg-->
-    
+
 
 
 
@@ -19487,7 +19494,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -19497,7 +19504,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -19554,7 +19561,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -19564,7 +19571,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -19621,7 +19628,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -19631,7 +19638,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -19688,7 +19695,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -19698,7 +19705,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -19755,7 +19762,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -19765,7 +19772,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -19822,7 +19829,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -19832,7 +19839,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -19889,7 +19896,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -19899,7 +19906,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -19956,7 +19963,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -19966,7 +19973,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -20023,7 +20030,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -20033,7 +20040,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -20090,7 +20097,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -20100,7 +20107,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -20142,9 +20149,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00250--mixed4a-00259.jpg-->
-    
+
 
 
 
@@ -20409,7 +20416,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -20419,7 +20426,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -20476,7 +20483,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -20486,7 +20493,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -20543,7 +20550,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -20553,7 +20560,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -20610,7 +20617,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -20620,7 +20627,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -20677,7 +20684,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -20687,7 +20694,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -20744,7 +20751,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -20754,7 +20761,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -20811,7 +20818,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -20821,7 +20828,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -20878,7 +20885,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -20888,7 +20895,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -20945,7 +20952,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -20955,7 +20962,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -21012,7 +21019,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -21022,7 +21029,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -21064,9 +21071,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00260--mixed4a-00269.jpg-->
-    
+
 
 
 
@@ -21341,7 +21348,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -21351,7 +21358,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -21408,7 +21415,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -21418,7 +21425,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -21475,7 +21482,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -21485,7 +21492,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -21542,7 +21549,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -21552,7 +21559,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -21609,7 +21616,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -21619,7 +21626,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -21676,7 +21683,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -21686,7 +21693,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -21743,7 +21750,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -21753,7 +21760,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -21810,7 +21817,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -21820,7 +21827,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -21877,7 +21884,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -21887,7 +21894,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -21944,7 +21951,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -21954,7 +21961,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -21996,9 +22003,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00270--mixed4a-00279.jpg-->
-    
+
 
 
 
@@ -22283,7 +22290,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -22293,7 +22300,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -22350,7 +22357,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -22360,7 +22367,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -22417,7 +22424,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -22427,7 +22434,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -22484,7 +22491,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -22494,7 +22501,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -22551,7 +22558,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -22561,7 +22568,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -22618,7 +22625,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -22628,7 +22635,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -22685,7 +22692,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -22695,7 +22702,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -22752,7 +22759,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -22762,7 +22769,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -22819,7 +22826,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -22829,7 +22836,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -22886,7 +22893,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -22896,7 +22903,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -22938,9 +22945,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00280--mixed4a-00289.jpg-->
-    
+
 
 
 
@@ -23235,7 +23242,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -23245,7 +23252,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -23302,7 +23309,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -23312,7 +23319,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -23369,7 +23376,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -23379,7 +23386,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -23436,7 +23443,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -23446,7 +23453,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -23503,7 +23510,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -23513,7 +23520,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -23570,7 +23577,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -23580,7 +23587,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -23637,7 +23644,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -23647,7 +23654,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -23704,7 +23711,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -23714,7 +23721,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -23771,7 +23778,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -23781,7 +23788,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -23838,7 +23845,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -23848,7 +23855,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -23890,9 +23897,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00290--mixed4a-00299.jpg-->
-    
+
 
 
 
@@ -24197,7 +24204,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -24207,7 +24214,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -24264,7 +24271,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -24274,7 +24281,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -24331,7 +24338,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -24341,7 +24348,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -24398,7 +24405,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -24408,7 +24415,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -24465,7 +24472,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -24475,7 +24482,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -24532,7 +24539,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -24542,7 +24549,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -24599,7 +24606,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -24609,7 +24616,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -24666,7 +24673,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -24676,7 +24683,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -24733,7 +24740,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -24743,7 +24750,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -24800,7 +24807,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -24810,7 +24817,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -24852,9 +24859,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00300--mixed4a-00309.jpg-->
-    
+
 
 
 
@@ -25169,7 +25176,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -25179,7 +25186,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -25236,7 +25243,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -25246,7 +25253,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -25303,7 +25310,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -25313,7 +25320,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -25370,7 +25377,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -25380,7 +25387,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -25437,7 +25444,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -25447,7 +25454,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -25504,7 +25511,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -25514,7 +25521,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -25571,7 +25578,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -25581,7 +25588,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -25638,7 +25645,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -25648,7 +25655,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -25705,7 +25712,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -25715,7 +25722,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -25772,7 +25779,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -25782,7 +25789,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -25824,9 +25831,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00310--mixed4a-00319.jpg-->
-    
+
 
 
 
@@ -26151,7 +26158,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -26161,7 +26168,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -26218,7 +26225,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -26228,7 +26235,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -26285,7 +26292,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -26295,7 +26302,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -26352,7 +26359,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -26362,7 +26369,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -26419,7 +26426,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -26429,7 +26436,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -26486,7 +26493,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -26496,7 +26503,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -26553,7 +26560,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -26563,7 +26570,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -26620,7 +26627,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -26630,7 +26637,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -26687,7 +26694,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -26697,7 +26704,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -26754,7 +26761,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -26764,7 +26771,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -26806,9 +26813,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00320--mixed4a-00329.jpg-->
-    
+
 
 
 
@@ -27143,7 +27150,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -27153,7 +27160,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -27210,7 +27217,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -27220,7 +27227,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -27277,7 +27284,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -27287,7 +27294,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -27344,7 +27351,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -27354,7 +27361,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -27411,7 +27418,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -27421,7 +27428,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -27478,7 +27485,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -27488,7 +27495,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -27545,7 +27552,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -27555,7 +27562,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -27612,7 +27619,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -27622,7 +27629,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -27679,7 +27686,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -27689,7 +27696,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -27746,7 +27753,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -27756,7 +27763,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -27798,9 +27805,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00330--mixed4a-00339.jpg-->
-    
+
 
 
 
@@ -28145,7 +28152,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -28155,7 +28162,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -28212,7 +28219,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -28222,7 +28229,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -28279,7 +28286,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -28289,7 +28296,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -28346,7 +28353,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -28356,7 +28363,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -28413,7 +28420,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -28423,7 +28430,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -28480,7 +28487,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -28490,7 +28497,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -28547,7 +28554,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -28557,7 +28564,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -28614,7 +28621,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -28624,7 +28631,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -28681,7 +28688,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -28691,7 +28698,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -28748,7 +28755,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -28758,7 +28765,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -28800,9 +28807,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00340--mixed4a-00349.jpg-->
-    
+
 
 
 
@@ -29157,7 +29164,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -29167,7 +29174,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -29224,7 +29231,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -29234,7 +29241,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -29291,7 +29298,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -29301,7 +29308,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -29358,7 +29365,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -29368,7 +29375,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -29425,7 +29432,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -29435,7 +29442,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -29492,7 +29499,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -29502,7 +29509,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -29559,7 +29566,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -29569,7 +29576,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -29626,7 +29633,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -29636,7 +29643,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -29693,7 +29700,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -29703,7 +29710,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -29760,7 +29767,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -29770,7 +29777,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -29812,9 +29819,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00350--mixed4a-00359.jpg-->
-    
+
 
 
 
@@ -30179,7 +30186,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -30189,7 +30196,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -30246,7 +30253,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -30256,7 +30263,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -30313,7 +30320,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -30323,7 +30330,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -30380,7 +30387,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -30390,7 +30397,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -30447,7 +30454,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -30457,7 +30464,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -30514,7 +30521,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -30524,7 +30531,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -30581,7 +30588,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -30591,7 +30598,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -30648,7 +30655,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -30658,7 +30665,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -30715,7 +30722,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -30725,7 +30732,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -30782,7 +30789,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -30792,7 +30799,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -30834,9 +30841,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00360--mixed4a-00369.jpg-->
-    
+
 
 
 
@@ -31211,7 +31218,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -31221,7 +31228,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -31278,7 +31285,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -31288,7 +31295,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -31345,7 +31352,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -31355,7 +31362,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -31412,7 +31419,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -31422,7 +31429,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -31479,7 +31486,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -31489,7 +31496,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -31546,7 +31553,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -31556,7 +31563,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -31613,7 +31620,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -31623,7 +31630,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -31680,7 +31687,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -31690,7 +31697,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -31747,7 +31754,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -31757,7 +31764,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -31814,7 +31821,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -31824,7 +31831,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -31866,9 +31873,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00370--mixed4a-00379.jpg-->
-    
+
 
 
 
@@ -32253,7 +32260,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -32263,7 +32270,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -32320,7 +32327,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -32330,7 +32337,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -32387,7 +32394,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -32397,7 +32404,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -32454,7 +32461,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -32464,7 +32471,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -32521,7 +32528,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -32531,7 +32538,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -32588,7 +32595,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -32598,7 +32605,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -32655,7 +32662,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -32665,7 +32672,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -32722,7 +32729,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -32732,7 +32739,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -32789,7 +32796,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -32799,7 +32806,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -32856,7 +32863,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -32866,7 +32873,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -32908,9 +32915,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00380--mixed4a-00389.jpg-->
-    
+
 
 
 
@@ -33305,7 +33312,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -33315,7 +33322,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -33372,7 +33379,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -33382,7 +33389,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -33439,7 +33446,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -33449,7 +33456,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -33506,7 +33513,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -33516,7 +33523,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -33573,7 +33580,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -33583,7 +33590,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -33640,7 +33647,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -33650,7 +33657,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -33707,7 +33714,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -33717,7 +33724,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -33774,7 +33781,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -33784,7 +33791,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -33841,7 +33848,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -33851,7 +33858,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -33908,7 +33915,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -33918,7 +33925,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -33960,9 +33967,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00390--mixed4a-00399.jpg-->
-    
+
 
 
 
@@ -34367,7 +34374,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -34377,7 +34384,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -34434,7 +34441,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -34444,7 +34451,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -34501,7 +34508,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -34511,7 +34518,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -34568,7 +34575,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -34578,7 +34585,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -34635,7 +34642,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -34645,7 +34652,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -34702,7 +34709,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -34712,7 +34719,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -34769,7 +34776,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -34779,7 +34786,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -34836,7 +34843,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -34846,7 +34853,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -34903,7 +34910,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -34913,7 +34920,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -34970,7 +34977,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -34980,7 +34987,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -35022,9 +35029,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00400--mixed4a-00409.jpg-->
-    
+
 
 
 
@@ -35439,7 +35446,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -35449,7 +35456,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -35506,7 +35513,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -35516,7 +35523,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -35573,7 +35580,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -35583,7 +35590,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -35640,7 +35647,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -35650,7 +35657,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -35707,7 +35714,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -35717,7 +35724,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -35774,7 +35781,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -35784,7 +35791,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -35841,7 +35848,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -35851,7 +35858,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -35908,7 +35915,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -35918,7 +35925,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -35975,7 +35982,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -35985,7 +35992,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -36042,7 +36049,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -36052,7 +36059,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -36094,9 +36101,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00410--mixed4a-00419.jpg-->
-    
+
 
 
 
@@ -36521,7 +36528,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -36531,7 +36538,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -36588,7 +36595,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -36598,7 +36605,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -36655,7 +36662,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -36665,7 +36672,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -36722,7 +36729,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -36732,7 +36739,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -36789,7 +36796,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -36799,7 +36806,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -36856,7 +36863,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -36866,7 +36873,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -36923,7 +36930,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -36933,7 +36940,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -36990,7 +36997,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -37000,7 +37007,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -37057,7 +37064,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -37067,7 +37074,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -37124,7 +37131,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -37134,7 +37141,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -37176,9 +37183,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00420--mixed4a-00429.jpg-->
-    
+
 
 
 
@@ -37613,7 +37620,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -37623,7 +37630,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -37680,7 +37687,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -37690,7 +37697,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -37747,7 +37754,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -37757,7 +37764,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -37814,7 +37821,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -37824,7 +37831,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -37881,7 +37888,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -37891,7 +37898,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -37948,7 +37955,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -37958,7 +37965,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -38015,7 +38022,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -38025,7 +38032,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -38082,7 +38089,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -38092,7 +38099,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -38149,7 +38156,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -38159,7 +38166,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -38216,7 +38223,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -38226,7 +38233,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -38268,9 +38275,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00430--mixed4a-00439.jpg-->
-    
+
 
 
 
@@ -38715,7 +38722,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -38725,7 +38732,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -38782,7 +38789,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -38792,7 +38799,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -38849,7 +38856,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -38859,7 +38866,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -38916,7 +38923,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -38926,7 +38933,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -38983,7 +38990,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -38993,7 +39000,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -39050,7 +39057,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -39060,7 +39067,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -39117,7 +39124,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -39127,7 +39134,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -39184,7 +39191,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -39194,7 +39201,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -39251,7 +39258,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -39261,7 +39268,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -39318,7 +39325,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -39328,7 +39335,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -39370,9 +39377,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00440--mixed4a-00449.jpg-->
-    
+
 
 
 
@@ -39827,7 +39834,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -39837,7 +39844,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -39894,7 +39901,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -39904,7 +39911,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -39961,7 +39968,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -39971,7 +39978,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -40028,7 +40035,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -40038,7 +40045,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -40095,7 +40102,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -40105,7 +40112,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -40162,7 +40169,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -40172,7 +40179,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -40229,7 +40236,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -40239,7 +40246,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -40296,7 +40303,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -40306,7 +40313,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -40363,7 +40370,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -40373,7 +40380,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -40430,7 +40437,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -40440,7 +40447,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -40482,9 +40489,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00450--mixed4a-00459.jpg-->
-    
+
 
 
 
@@ -40949,7 +40956,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -40959,7 +40966,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -41016,7 +41023,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -41026,7 +41033,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -41083,7 +41090,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -41093,7 +41100,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -41150,7 +41157,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -41160,7 +41167,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -41217,7 +41224,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -41227,7 +41234,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -41284,7 +41291,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -41294,7 +41301,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -41351,7 +41358,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -41361,7 +41368,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -41418,7 +41425,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -41428,7 +41435,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -41485,7 +41492,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -41495,7 +41502,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -41552,7 +41559,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -41562,7 +41569,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -41604,9 +41611,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00460--mixed4a-00469.jpg-->
-    
+
 
 
 
@@ -42081,7 +42088,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -42091,7 +42098,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -42148,7 +42155,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -42158,7 +42165,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -42215,7 +42222,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -42225,7 +42232,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -42282,7 +42289,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -42292,7 +42299,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -42349,7 +42356,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -42359,7 +42366,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -42416,7 +42423,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -42426,7 +42433,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -42483,7 +42490,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -42493,7 +42500,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -42550,7 +42557,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -42560,7 +42567,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -42617,7 +42624,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -42627,7 +42634,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -42684,7 +42691,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -42694,7 +42701,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -42736,9 +42743,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00470--mixed4a-00479.jpg-->
-    
+
 
 
 
@@ -43223,7 +43230,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -43233,7 +43240,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -43290,7 +43297,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -43300,7 +43307,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -43357,7 +43364,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -43367,7 +43374,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -43424,7 +43431,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -43434,7 +43441,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -43491,7 +43498,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -43501,7 +43508,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -43558,7 +43565,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -43568,7 +43575,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -43625,7 +43632,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -43635,7 +43642,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -43692,7 +43699,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -43702,7 +43709,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -43759,7 +43766,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -43769,7 +43776,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -43826,7 +43833,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -43836,7 +43843,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -43878,9 +43885,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00480--mixed4a-00489.jpg-->
-    
+
 
 
 
@@ -44375,7 +44382,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -44385,7 +44392,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -44442,7 +44449,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -44452,7 +44459,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -44509,7 +44516,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -44519,7 +44526,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -44576,7 +44583,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -44586,7 +44593,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -44643,7 +44650,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -44653,7 +44660,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -44710,7 +44717,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -44720,7 +44727,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -44777,7 +44784,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -44787,7 +44794,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -44844,7 +44851,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -44854,7 +44861,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -44911,7 +44918,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -44921,7 +44928,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -44978,7 +44985,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -44988,7 +44995,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -45030,9 +45037,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00490--mixed4a-00499.jpg-->
-    
+
 
 
 
@@ -45537,7 +45544,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -45547,7 +45554,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -45604,7 +45611,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -45614,7 +45621,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -45671,7 +45678,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -45681,7 +45688,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -45738,7 +45745,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -45748,7 +45755,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -45805,7 +45812,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -45815,7 +45822,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -45872,7 +45879,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -45882,7 +45889,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -45939,7 +45946,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -45949,7 +45956,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -46006,7 +46013,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -46016,7 +46023,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -46073,7 +46080,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -46083,7 +46090,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -46140,7 +46147,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -46150,7 +46157,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -46192,9 +46199,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4a-00500--mixed4a-00507.jpg-->
-    
+
 
 
 
@@ -46709,7 +46716,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -46719,7 +46726,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -46776,7 +46783,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -46786,7 +46793,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -46843,7 +46850,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -46853,7 +46860,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -46910,7 +46917,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -46920,7 +46927,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -46977,7 +46984,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -46987,7 +46994,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -47044,7 +47051,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -47054,7 +47061,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -47111,7 +47118,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -47121,7 +47128,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -47178,7 +47185,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -47188,7 +47195,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -47230,9 +47237,8 @@
       </div>
       </d-figure>
       </li>
-  
+
   </ul>
   </d-article>
   <distill-footer></distill-footer>
 </body>
-  

--- a/public/appendix/googlenet/4b.html
+++ b/public/appendix/googlenet/4b.html
@@ -5,21 +5,21 @@
   <meta charset="utf8">
   <script src="https://distill.pub/template.v2.js"></script>
   <style>
-  
+
     d-article {
       line-height: 1em;
     }
-    
+
     d-byline,
     d-appendix {
       display: none;
     }
-  
+
     h4 {
       display: block;
       width: 100%;
     }
-    
+
     d-figure {
       display: flex;
       flex-flow: row;
@@ -31,7 +31,7 @@
       margin-bottom: 1em;
       justify-content: center;
     }
-    
+
     .positive,
     .negative {
       display: flex;
@@ -40,7 +40,7 @@
       align-content: flex-start;
       max-width: 370px;
     }
-    
+
     .positive {
       padding-left: 1em;
       padding-right: 1em;
@@ -50,14 +50,14 @@
       border-right: 1px solid rgba(0,0,0,0.1);
       justify-content: space-between;
     }
-    
+
     .figcaption {
       display: block;
       color: rgba(0, 0, 0, 0.6);
       font-size: 12px;
       line-height: 1.5em;
     }
-    
+
     .diversity {
       display: flex;
       flex-flow: row;
@@ -65,61 +65,61 @@
       width: 148px;
       height: 147px
     }
-    
+
     .diversity > div {
       zoom: 0.496598639;
     }
-    
+
     .channel {
       margin-right: 1em;
     }
-    
+
     .channels {
       grid-column: screen;
       list-style: none;
       padding-left: 0;
     }
-    
+
     .channels li {
       contain: content;
       overflow: hidden;
     }
-    
+
     .sprite {
       display: inline-block;
       margin: 1px;
       width: 147px;
       height: 147px;
     }
-    
+
     .sprite.neuron {
       background-position-x: 0px;
     }
-    
+
     .sprite.channel {
       background-position-x: -147px;
     }
-    
+
     .sprite.channel-negative {
       background-position-x: -294px;
     }
-    
+
     .sprite.channel-diversity-0 {
       background-position-x: -441px;
     }
-    
+
     .sprite.channel-diversity-1 {
       background-position-x: -588px;
     }
-    
+
     .sprite.channel-diversity-2 {
       background-position-x: -735px;
     }
-    
+
     .sprite.channel-diversity-3 {
       background-position-x: -882px;
     }
-    
+
     .dataset-examples {
       display: flex;
       flex-flow: row;
@@ -127,7 +127,7 @@
       width: 375px;
       height: 147px
     }
-    
+
     .dataset-examples .sprite {
       height: 73px;
       width: 73px;
@@ -136,16 +136,16 @@
       margin-bottom: 0;
       margin-right: 0;
     }
-    
-    
+
+
       .channels .sprite.dataset-index-0 {
         background-position-x: -1029px !important;
       }
-      
+
       .channels .sprite.index-0 {
         background-position-y: -0px;
       }
-      
+
       .channels .dataset-negative .sprite.index-0 {
         background-position-y: -74px !important;
       }
@@ -153,11 +153,11 @@
       .channels .sprite.dataset-index-1 {
         background-position-x: -1103px !important;
       }
-      
+
       .channels .sprite.index-1 {
         background-position-y: -147px;
       }
-      
+
       .channels .dataset-negative .sprite.index-1 {
         background-position-y: -221px !important;
       }
@@ -165,11 +165,11 @@
       .channels .sprite.dataset-index-2 {
         background-position-x: -1177px !important;
       }
-      
+
       .channels .sprite.index-2 {
         background-position-y: -294px;
       }
-      
+
       .channels .dataset-negative .sprite.index-2 {
         background-position-y: -368px !important;
       }
@@ -177,11 +177,11 @@
       .channels .sprite.dataset-index-3 {
         background-position-x: -1251px !important;
       }
-      
+
       .channels .sprite.index-3 {
         background-position-y: -441px;
       }
-      
+
       .channels .dataset-negative .sprite.index-3 {
         background-position-y: -515px !important;
       }
@@ -189,11 +189,11 @@
       .channels .sprite.dataset-index-4 {
         background-position-x: -1325px !important;
       }
-      
+
       .channels .sprite.index-4 {
         background-position-y: -588px;
       }
-      
+
       .channels .dataset-negative .sprite.index-4 {
         background-position-y: -662px !important;
       }
@@ -201,11 +201,11 @@
       .channels .sprite.dataset-index-5 {
         background-position-x: -1399px !important;
       }
-      
+
       .channels .sprite.index-5 {
         background-position-y: -735px;
       }
-      
+
       .channels .dataset-negative .sprite.index-5 {
         background-position-y: -809px !important;
       }
@@ -213,11 +213,11 @@
       .channels .sprite.dataset-index-6 {
         background-position-x: -1473px !important;
       }
-      
+
       .channels .sprite.index-6 {
         background-position-y: -882px;
       }
-      
+
       .channels .dataset-negative .sprite.index-6 {
         background-position-y: -956px !important;
       }
@@ -225,11 +225,11 @@
       .channels .sprite.dataset-index-7 {
         background-position-x: -1547px !important;
       }
-      
+
       .channels .sprite.index-7 {
         background-position-y: -1029px;
       }
-      
+
       .channels .dataset-negative .sprite.index-7 {
         background-position-y: -1103px !important;
       }
@@ -237,11 +237,11 @@
       .channels .sprite.dataset-index-8 {
         background-position-x: -1621px !important;
       }
-      
+
       .channels .sprite.index-8 {
         background-position-y: -1176px;
       }
-      
+
       .channels .dataset-negative .sprite.index-8 {
         background-position-y: -1250px !important;
       }
@@ -249,20 +249,20 @@
       .channels .sprite.dataset-index-9 {
         background-position-x: -1695px !important;
       }
-      
+
       .channels .sprite.index-9 {
         background-position-y: -1323px;
       }
-      
+
       .channels .dataset-negative .sprite.index-9 {
         background-position-y: -1397px !important;
       }
-    
-    
+
+
     .article-nav {
       grid-column: page;
     }
-    
+
     .navlist li {
       display: inline;
       list-style-type: none;
@@ -300,10 +300,10 @@
     <h1>Layer 4b</h1>
   </d-title>
   <d-article>
-  
+
   <nav class="article-nav">
-  
-    
+
+
     <ul class="navlist">
       <li><a href="https://distill.pub/2017/feature-visualization/appendix/">Appendix overview</a></li>
       <li><a href="https://distill.pub/2017/feature-visualization/">Main article</a></li>
@@ -319,7 +319,7 @@
         <a href="4a.html">Layer 4a</a>
       </li>
       <li>
-        <a href="4b.html">Layer 4b</a>
+        <a href="4b.html"><b>Layer 4b</b></a>
       </li>
       <li>
         <a href="4c.html">Layer 4c</a>
@@ -337,14 +337,21 @@
         <a href="5b.html">Layer 5b</a>
       </li>
     </ul>
-  
+
+    <ul class="navlist">
+      <li> <a href="4b.html#4b-0">4b 1x1</a> <span style="color: #777;">(0:160)</span> </li>
+      <li> <a href="4b.html#4b-160">4b 3x3</a> <span style="color: #777;">(160:384)</span> </li>
+      <li> <a href="4b.html#4b-384">4b 5x5</a> <span style="color: #777;">(384:448)</span> </li>
+      <li> <a href="4b.html#4b-448">4b pool</a> <span style="color: #777;">(448:512)</span> </li>
+    </ul>
+
   </nav>
-  
+
   <hr style="margin-top: 20px;"/>
-  
+
   <ul class="channels">
     <!--mixed4b-00000--mixed4b-00009.jpg-->
-    
+
       <li id="channel-0">
       <d-figure id="4b-0">
       <style data-img-src="images/mixed4b-00000--mixed4b-00009.jpg" data-channel="0"></style>
@@ -359,7 +366,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -369,7 +376,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -426,7 +433,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -436,7 +443,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -493,7 +500,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -503,7 +510,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -560,7 +567,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -570,7 +577,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -627,7 +634,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -637,7 +644,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -694,7 +701,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -704,7 +711,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -761,7 +768,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -771,7 +778,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -828,7 +835,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -838,7 +845,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -895,7 +902,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -905,7 +912,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -962,7 +969,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -972,7 +979,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -1014,9 +1021,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00010--mixed4b-00019.jpg-->
-    
+
 
 
 
@@ -1041,7 +1048,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -1051,7 +1058,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -1108,7 +1115,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -1118,7 +1125,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -1175,7 +1182,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -1185,7 +1192,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -1242,7 +1249,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -1252,7 +1259,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -1309,7 +1316,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -1319,7 +1326,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -1376,7 +1383,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -1386,7 +1393,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -1443,7 +1450,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -1453,7 +1460,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -1510,7 +1517,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -1520,7 +1527,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -1577,7 +1584,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -1587,7 +1594,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -1644,7 +1651,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -1654,7 +1661,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -1696,9 +1703,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00020--mixed4b-00029.jpg-->
-    
+
 
 
 
@@ -1733,7 +1740,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -1743,7 +1750,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -1800,7 +1807,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -1810,7 +1817,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -1867,7 +1874,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -1877,7 +1884,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -1934,7 +1941,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -1944,7 +1951,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -2001,7 +2008,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -2011,7 +2018,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -2068,7 +2075,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -2078,7 +2085,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -2135,7 +2142,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -2145,7 +2152,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -2202,7 +2209,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -2212,7 +2219,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -2269,7 +2276,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -2279,7 +2286,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -2336,7 +2343,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -2346,7 +2353,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -2388,9 +2395,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00030--mixed4b-00039.jpg-->
-    
+
 
 
 
@@ -2435,7 +2442,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -2445,7 +2452,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -2502,7 +2509,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -2512,7 +2519,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -2569,7 +2576,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -2579,7 +2586,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -2636,7 +2643,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -2646,7 +2653,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -2703,7 +2710,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -2713,7 +2720,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -2770,7 +2777,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -2780,7 +2787,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -2837,7 +2844,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -2847,7 +2854,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -2904,7 +2911,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -2914,7 +2921,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -2971,7 +2978,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -2981,7 +2988,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -3038,7 +3045,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -3048,7 +3055,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -3090,9 +3097,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00040--mixed4b-00049.jpg-->
-    
+
 
 
 
@@ -3147,7 +3154,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -3157,7 +3164,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -3214,7 +3221,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -3224,7 +3231,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -3281,7 +3288,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -3291,7 +3298,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -3348,7 +3355,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -3358,7 +3365,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -3415,7 +3422,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -3425,7 +3432,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -3482,7 +3489,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -3492,7 +3499,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -3549,7 +3556,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -3559,7 +3566,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -3616,7 +3623,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -3626,7 +3633,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -3683,7 +3690,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -3693,7 +3700,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -3750,7 +3757,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -3760,7 +3767,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -3802,9 +3809,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00050--mixed4b-00059.jpg-->
-    
+
 
 
 
@@ -3869,7 +3876,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -3879,7 +3886,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -3936,7 +3943,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -3946,7 +3953,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -4003,7 +4010,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -4013,7 +4020,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -4070,7 +4077,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -4080,7 +4087,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -4137,7 +4144,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -4147,7 +4154,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -4204,7 +4211,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -4214,7 +4221,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -4271,7 +4278,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -4281,7 +4288,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -4338,7 +4345,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -4348,7 +4355,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -4405,7 +4412,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -4415,7 +4422,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -4472,7 +4479,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -4482,7 +4489,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -4524,9 +4531,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00060--mixed4b-00069.jpg-->
-    
+
 
 
 
@@ -4601,7 +4608,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -4611,7 +4618,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -4668,7 +4675,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -4678,7 +4685,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -4735,7 +4742,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -4745,7 +4752,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -4802,7 +4809,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -4812,7 +4819,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -4869,7 +4876,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -4879,7 +4886,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -4936,7 +4943,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -4946,7 +4953,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -5003,7 +5010,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -5013,7 +5020,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -5070,7 +5077,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -5080,7 +5087,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -5137,7 +5144,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -5147,7 +5154,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -5204,7 +5211,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -5214,7 +5221,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -5256,9 +5263,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00070--mixed4b-00079.jpg-->
-    
+
 
 
 
@@ -5343,7 +5350,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -5353,7 +5360,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -5410,7 +5417,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -5420,7 +5427,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -5477,7 +5484,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -5487,7 +5494,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -5544,7 +5551,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -5554,7 +5561,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -5611,7 +5618,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -5621,7 +5628,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -5678,7 +5685,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -5688,7 +5695,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -5745,7 +5752,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -5755,7 +5762,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -5812,7 +5819,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -5822,7 +5829,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -5879,7 +5886,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -5889,7 +5896,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -5946,7 +5953,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -5956,7 +5963,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -5998,9 +6005,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00080--mixed4b-00089.jpg-->
-    
+
 
 
 
@@ -6095,7 +6102,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -6105,7 +6112,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -6162,7 +6169,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -6172,7 +6179,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -6229,7 +6236,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -6239,7 +6246,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -6296,7 +6303,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -6306,7 +6313,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -6363,7 +6370,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -6373,7 +6380,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -6430,7 +6437,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -6440,7 +6447,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -6497,7 +6504,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -6507,7 +6514,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -6564,7 +6571,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -6574,7 +6581,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -6631,7 +6638,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -6641,7 +6648,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -6698,7 +6705,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -6708,7 +6715,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -6750,9 +6757,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00090--mixed4b-00099.jpg-->
-    
+
 
 
 
@@ -6857,7 +6864,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -6867,7 +6874,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -6924,7 +6931,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -6934,7 +6941,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -6991,7 +6998,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -7001,7 +7008,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -7058,7 +7065,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -7068,7 +7075,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -7125,7 +7132,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -7135,7 +7142,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -7192,7 +7199,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -7202,7 +7209,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -7259,7 +7266,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -7269,7 +7276,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -7326,7 +7333,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -7336,7 +7343,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -7393,7 +7400,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -7403,7 +7410,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -7460,7 +7467,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -7470,7 +7477,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -7512,9 +7519,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00100--mixed4b-00109.jpg-->
-    
+
 
 
 
@@ -7629,7 +7636,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -7639,7 +7646,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -7696,7 +7703,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -7706,7 +7713,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -7763,7 +7770,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -7773,7 +7780,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -7830,7 +7837,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -7840,7 +7847,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -7897,7 +7904,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -7907,7 +7914,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -7964,7 +7971,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -7974,7 +7981,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -8031,7 +8038,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -8041,7 +8048,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -8098,7 +8105,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -8108,7 +8115,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -8165,7 +8172,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -8175,7 +8182,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -8232,7 +8239,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -8242,7 +8249,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -8284,9 +8291,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00110--mixed4b-00119.jpg-->
-    
+
 
 
 
@@ -8411,7 +8418,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -8421,7 +8428,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -8478,7 +8485,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -8488,7 +8495,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -8545,7 +8552,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -8555,7 +8562,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -8612,7 +8619,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -8622,7 +8629,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -8679,7 +8686,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -8689,7 +8696,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -8746,7 +8753,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -8756,7 +8763,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -8813,7 +8820,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -8823,7 +8830,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -8880,7 +8887,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -8890,7 +8897,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -8947,7 +8954,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -8957,7 +8964,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -9014,7 +9021,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -9024,7 +9031,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -9066,9 +9073,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00120--mixed4b-00129.jpg-->
-    
+
 
 
 
@@ -9203,7 +9210,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -9213,7 +9220,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -9270,7 +9277,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -9280,7 +9287,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -9337,7 +9344,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -9347,7 +9354,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -9404,7 +9411,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -9414,7 +9421,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -9471,7 +9478,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -9481,7 +9488,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -9538,7 +9545,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -9548,7 +9555,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -9605,7 +9612,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -9615,7 +9622,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -9672,7 +9679,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -9682,7 +9689,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -9739,7 +9746,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -9749,7 +9756,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -9806,7 +9813,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -9816,7 +9823,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -9858,9 +9865,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00130--mixed4b-00139.jpg-->
-    
+
 
 
 
@@ -10005,7 +10012,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -10015,7 +10022,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -10072,7 +10079,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -10082,7 +10089,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -10139,7 +10146,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -10149,7 +10156,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -10206,7 +10213,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -10216,7 +10223,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -10273,7 +10280,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -10283,7 +10290,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -10340,7 +10347,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -10350,7 +10357,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -10407,7 +10414,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -10417,7 +10424,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -10474,7 +10481,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -10484,7 +10491,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -10541,7 +10548,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -10551,7 +10558,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -10608,7 +10615,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -10618,7 +10625,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -10660,9 +10667,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00140--mixed4b-00149.jpg-->
-    
+
 
 
 
@@ -10817,7 +10824,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -10827,7 +10834,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -10884,7 +10891,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -10894,7 +10901,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -10951,7 +10958,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -10961,7 +10968,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -11018,7 +11025,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -11028,7 +11035,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -11085,7 +11092,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -11095,7 +11102,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -11152,7 +11159,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -11162,7 +11169,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -11219,7 +11226,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -11229,7 +11236,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -11286,7 +11293,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -11296,7 +11303,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -11353,7 +11360,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -11363,7 +11370,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -11420,7 +11427,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -11430,7 +11437,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -11472,9 +11479,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00150--mixed4b-00159.jpg-->
-    
+
 
 
 
@@ -11639,7 +11646,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -11649,7 +11656,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -11706,7 +11713,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -11716,7 +11723,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -11773,7 +11780,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -11783,7 +11790,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -11840,7 +11847,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -11850,7 +11857,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -11907,7 +11914,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -11917,7 +11924,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -11974,7 +11981,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -11984,7 +11991,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -12041,7 +12048,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -12051,7 +12058,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -12108,7 +12115,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -12118,7 +12125,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -12175,7 +12182,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -12185,7 +12192,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -12242,7 +12249,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -12252,7 +12259,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -12294,9 +12301,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00160--mixed4b-00169.jpg-->
-    
+
 
 
 
@@ -12471,7 +12478,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -12481,7 +12488,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -12538,7 +12545,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -12548,7 +12555,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -12605,7 +12612,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -12615,7 +12622,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -12672,7 +12679,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -12682,7 +12689,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -12739,7 +12746,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -12749,7 +12756,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -12806,7 +12813,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -12816,7 +12823,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -12873,7 +12880,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -12883,7 +12890,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -12940,7 +12947,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -12950,7 +12957,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -13007,7 +13014,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -13017,7 +13024,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -13074,7 +13081,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -13084,7 +13091,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -13126,9 +13133,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00170--mixed4b-00179.jpg-->
-    
+
 
 
 
@@ -13313,7 +13320,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -13323,7 +13330,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -13380,7 +13387,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -13390,7 +13397,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -13447,7 +13454,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -13457,7 +13464,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -13514,7 +13521,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -13524,7 +13531,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -13581,7 +13588,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -13591,7 +13598,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -13648,7 +13655,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -13658,7 +13665,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -13715,7 +13722,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -13725,7 +13732,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -13782,7 +13789,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -13792,7 +13799,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -13849,7 +13856,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -13859,7 +13866,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -13916,7 +13923,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -13926,7 +13933,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -13968,9 +13975,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00180--mixed4b-00189.jpg-->
-    
+
 
 
 
@@ -14165,7 +14172,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -14175,7 +14182,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -14232,7 +14239,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -14242,7 +14249,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -14299,7 +14306,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -14309,7 +14316,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -14366,7 +14373,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -14376,7 +14383,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -14433,7 +14440,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -14443,7 +14450,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -14500,7 +14507,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -14510,7 +14517,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -14567,7 +14574,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -14577,7 +14584,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -14634,7 +14641,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -14644,7 +14651,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -14701,7 +14708,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -14711,7 +14718,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -14768,7 +14775,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -14778,7 +14785,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -14820,9 +14827,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00190--mixed4b-00199.jpg-->
-    
+
 
 
 
@@ -15027,7 +15034,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -15037,7 +15044,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -15094,7 +15101,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -15104,7 +15111,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -15161,7 +15168,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -15171,7 +15178,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -15228,7 +15235,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -15238,7 +15245,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -15295,7 +15302,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -15305,7 +15312,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -15362,7 +15369,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -15372,7 +15379,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -15429,7 +15436,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -15439,7 +15446,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -15496,7 +15503,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -15506,7 +15513,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -15563,7 +15570,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -15573,7 +15580,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -15630,7 +15637,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -15640,7 +15647,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -15682,9 +15689,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00200--mixed4b-00209.jpg-->
-    
+
 
 
 
@@ -15899,7 +15906,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -15909,7 +15916,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -15966,7 +15973,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -15976,7 +15983,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -16033,7 +16040,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -16043,7 +16050,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -16100,7 +16107,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -16110,7 +16117,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -16167,7 +16174,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -16177,7 +16184,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -16234,7 +16241,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -16244,7 +16251,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -16301,7 +16308,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -16311,7 +16318,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -16368,7 +16375,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -16378,7 +16385,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -16435,7 +16442,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -16445,7 +16452,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -16502,7 +16509,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -16512,7 +16519,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -16554,9 +16561,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00210--mixed4b-00219.jpg-->
-    
+
 
 
 
@@ -16781,7 +16788,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -16791,7 +16798,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -16848,7 +16855,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -16858,7 +16865,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -16915,7 +16922,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -16925,7 +16932,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -16982,7 +16989,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -16992,7 +16999,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -17049,7 +17056,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -17059,7 +17066,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -17116,7 +17123,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -17126,7 +17133,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -17183,7 +17190,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -17193,7 +17200,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -17250,7 +17257,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -17260,7 +17267,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -17317,7 +17324,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -17327,7 +17334,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -17384,7 +17391,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -17394,7 +17401,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -17436,9 +17443,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00220--mixed4b-00229.jpg-->
-    
+
 
 
 
@@ -17673,7 +17680,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -17683,7 +17690,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -17740,7 +17747,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -17750,7 +17757,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -17807,7 +17814,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -17817,7 +17824,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -17874,7 +17881,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -17884,7 +17891,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -17941,7 +17948,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -17951,7 +17958,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -18008,7 +18015,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -18018,7 +18025,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -18075,7 +18082,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -18085,7 +18092,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -18142,7 +18149,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -18152,7 +18159,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -18209,7 +18216,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -18219,7 +18226,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -18276,7 +18283,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -18286,7 +18293,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -18328,9 +18335,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00230--mixed4b-00239.jpg-->
-    
+
 
 
 
@@ -18575,7 +18582,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -18585,7 +18592,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -18642,7 +18649,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -18652,7 +18659,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -18709,7 +18716,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -18719,7 +18726,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -18776,7 +18783,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -18786,7 +18793,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -18843,7 +18850,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -18853,7 +18860,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -18910,7 +18917,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -18920,7 +18927,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -18977,7 +18984,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -18987,7 +18994,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -19044,7 +19051,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -19054,7 +19061,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -19111,7 +19118,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -19121,7 +19128,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -19178,7 +19185,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -19188,7 +19195,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -19230,9 +19237,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00240--mixed4b-00249.jpg-->
-    
+
 
 
 
@@ -19487,7 +19494,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -19497,7 +19504,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -19554,7 +19561,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -19564,7 +19571,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -19621,7 +19628,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -19631,7 +19638,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -19688,7 +19695,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -19698,7 +19705,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -19755,7 +19762,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -19765,7 +19772,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -19822,7 +19829,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -19832,7 +19839,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -19889,7 +19896,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -19899,7 +19906,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -19956,7 +19963,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -19966,7 +19973,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -20023,7 +20030,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -20033,7 +20040,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -20090,7 +20097,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -20100,7 +20107,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -20142,9 +20149,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00250--mixed4b-00259.jpg-->
-    
+
 
 
 
@@ -20409,7 +20416,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -20419,7 +20426,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -20476,7 +20483,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -20486,7 +20493,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -20543,7 +20550,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -20553,7 +20560,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -20610,7 +20617,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -20620,7 +20627,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -20677,7 +20684,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -20687,7 +20694,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -20744,7 +20751,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -20754,7 +20761,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -20811,7 +20818,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -20821,7 +20828,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -20878,7 +20885,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -20888,7 +20895,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -20945,7 +20952,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -20955,7 +20962,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -21012,7 +21019,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -21022,7 +21029,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -21064,9 +21071,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00260--mixed4b-00269.jpg-->
-    
+
 
 
 
@@ -21341,7 +21348,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -21351,7 +21358,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -21408,7 +21415,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -21418,7 +21425,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -21475,7 +21482,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -21485,7 +21492,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -21542,7 +21549,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -21552,7 +21559,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -21609,7 +21616,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -21619,7 +21626,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -21676,7 +21683,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -21686,7 +21693,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -21743,7 +21750,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -21753,7 +21760,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -21810,7 +21817,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -21820,7 +21827,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -21877,7 +21884,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -21887,7 +21894,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -21944,7 +21951,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -21954,7 +21961,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -21996,9 +22003,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00270--mixed4b-00279.jpg-->
-    
+
 
 
 
@@ -22283,7 +22290,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -22293,7 +22300,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -22350,7 +22357,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -22360,7 +22367,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -22417,7 +22424,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -22427,7 +22434,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -22484,7 +22491,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -22494,7 +22501,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -22551,7 +22558,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -22561,7 +22568,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -22618,7 +22625,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -22628,7 +22635,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -22685,7 +22692,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -22695,7 +22702,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -22752,7 +22759,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -22762,7 +22769,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -22819,7 +22826,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -22829,7 +22836,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -22886,7 +22893,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -22896,7 +22903,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -22938,9 +22945,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00280--mixed4b-00289.jpg-->
-    
+
 
 
 
@@ -23235,7 +23242,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -23245,7 +23252,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -23302,7 +23309,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -23312,7 +23319,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -23369,7 +23376,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -23379,7 +23386,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -23436,7 +23443,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -23446,7 +23453,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -23503,7 +23510,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -23513,7 +23520,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -23570,7 +23577,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -23580,7 +23587,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -23637,7 +23644,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -23647,7 +23654,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -23704,7 +23711,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -23714,7 +23721,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -23771,7 +23778,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -23781,7 +23788,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -23838,7 +23845,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -23848,7 +23855,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -23890,9 +23897,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00290--mixed4b-00299.jpg-->
-    
+
 
 
 
@@ -24197,7 +24204,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -24207,7 +24214,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -24264,7 +24271,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -24274,7 +24281,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -24331,7 +24338,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -24341,7 +24348,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -24398,7 +24405,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -24408,7 +24415,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -24465,7 +24472,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -24475,7 +24482,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -24532,7 +24539,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -24542,7 +24549,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -24599,7 +24606,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -24609,7 +24616,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -24666,7 +24673,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -24676,7 +24683,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -24733,7 +24740,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -24743,7 +24750,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -24800,7 +24807,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -24810,7 +24817,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -24852,9 +24859,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00300--mixed4b-00309.jpg-->
-    
+
 
 
 
@@ -25169,7 +25176,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -25179,7 +25186,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -25236,7 +25243,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -25246,7 +25253,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -25303,7 +25310,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -25313,7 +25320,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -25370,7 +25377,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -25380,7 +25387,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -25437,7 +25444,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -25447,7 +25454,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -25504,7 +25511,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -25514,7 +25521,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -25571,7 +25578,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -25581,7 +25588,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -25638,7 +25645,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -25648,7 +25655,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -25705,7 +25712,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -25715,7 +25722,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -25772,7 +25779,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -25782,7 +25789,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -25824,9 +25831,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00310--mixed4b-00319.jpg-->
-    
+
 
 
 
@@ -26151,7 +26158,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -26161,7 +26168,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -26218,7 +26225,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -26228,7 +26235,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -26285,7 +26292,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -26295,7 +26302,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -26352,7 +26359,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -26362,7 +26369,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -26419,7 +26426,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -26429,7 +26436,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -26486,7 +26493,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -26496,7 +26503,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -26553,7 +26560,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -26563,7 +26570,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -26620,7 +26627,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -26630,7 +26637,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -26687,7 +26694,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -26697,7 +26704,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -26754,7 +26761,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -26764,7 +26771,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -26806,9 +26813,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00320--mixed4b-00329.jpg-->
-    
+
 
 
 
@@ -27143,7 +27150,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -27153,7 +27160,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -27210,7 +27217,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -27220,7 +27227,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -27277,7 +27284,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -27287,7 +27294,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -27344,7 +27351,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -27354,7 +27361,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -27411,7 +27418,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -27421,7 +27428,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -27478,7 +27485,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -27488,7 +27495,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -27545,7 +27552,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -27555,7 +27562,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -27612,7 +27619,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -27622,7 +27629,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -27679,7 +27686,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -27689,7 +27696,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -27746,7 +27753,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -27756,7 +27763,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -27798,9 +27805,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00330--mixed4b-00339.jpg-->
-    
+
 
 
 
@@ -28145,7 +28152,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -28155,7 +28162,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -28212,7 +28219,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -28222,7 +28229,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -28279,7 +28286,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -28289,7 +28296,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -28346,7 +28353,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -28356,7 +28363,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -28413,7 +28420,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -28423,7 +28430,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -28480,7 +28487,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -28490,7 +28497,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -28547,7 +28554,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -28557,7 +28564,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -28614,7 +28621,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -28624,7 +28631,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -28681,7 +28688,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -28691,7 +28698,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -28748,7 +28755,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -28758,7 +28765,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -28800,9 +28807,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00340--mixed4b-00349.jpg-->
-    
+
 
 
 
@@ -29157,7 +29164,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -29167,7 +29174,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -29224,7 +29231,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -29234,7 +29241,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -29291,7 +29298,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -29301,7 +29308,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -29358,7 +29365,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -29368,7 +29375,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -29425,7 +29432,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -29435,7 +29442,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -29492,7 +29499,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -29502,7 +29509,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -29559,7 +29566,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -29569,7 +29576,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -29626,7 +29633,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -29636,7 +29643,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -29693,7 +29700,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -29703,7 +29710,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -29760,7 +29767,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -29770,7 +29777,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -29812,9 +29819,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00350--mixed4b-00359.jpg-->
-    
+
 
 
 
@@ -30179,7 +30186,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -30189,7 +30196,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -30246,7 +30253,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -30256,7 +30263,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -30313,7 +30320,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -30323,7 +30330,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -30380,7 +30387,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -30390,7 +30397,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -30447,7 +30454,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -30457,7 +30464,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -30514,7 +30521,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -30524,7 +30531,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -30581,7 +30588,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -30591,7 +30598,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -30648,7 +30655,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -30658,7 +30665,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -30715,7 +30722,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -30725,7 +30732,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -30782,7 +30789,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -30792,7 +30799,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -30834,9 +30841,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00360--mixed4b-00369.jpg-->
-    
+
 
 
 
@@ -31211,7 +31218,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -31221,7 +31228,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -31278,7 +31285,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -31288,7 +31295,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -31345,7 +31352,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -31355,7 +31362,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -31412,7 +31419,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -31422,7 +31429,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -31479,7 +31486,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -31489,7 +31496,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -31546,7 +31553,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -31556,7 +31563,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -31613,7 +31620,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -31623,7 +31630,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -31680,7 +31687,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -31690,7 +31697,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -31747,7 +31754,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -31757,7 +31764,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -31814,7 +31821,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -31824,7 +31831,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -31866,9 +31873,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00370--mixed4b-00379.jpg-->
-    
+
 
 
 
@@ -32253,7 +32260,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -32263,7 +32270,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -32320,7 +32327,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -32330,7 +32337,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -32387,7 +32394,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -32397,7 +32404,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -32454,7 +32461,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -32464,7 +32471,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -32521,7 +32528,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -32531,7 +32538,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -32588,7 +32595,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -32598,7 +32605,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -32655,7 +32662,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -32665,7 +32672,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -32722,7 +32729,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -32732,7 +32739,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -32789,7 +32796,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -32799,7 +32806,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -32856,7 +32863,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -32866,7 +32873,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -32908,9 +32915,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00380--mixed4b-00389.jpg-->
-    
+
 
 
 
@@ -33305,7 +33312,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -33315,7 +33322,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -33372,7 +33379,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -33382,7 +33389,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -33439,7 +33446,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -33449,7 +33456,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -33506,7 +33513,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -33516,7 +33523,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -33573,7 +33580,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -33583,7 +33590,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -33640,7 +33647,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -33650,7 +33657,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -33707,7 +33714,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -33717,7 +33724,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -33774,7 +33781,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -33784,7 +33791,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -33841,7 +33848,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -33851,7 +33858,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -33908,7 +33915,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -33918,7 +33925,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -33960,9 +33967,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00390--mixed4b-00399.jpg-->
-    
+
 
 
 
@@ -34367,7 +34374,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -34377,7 +34384,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -34434,7 +34441,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -34444,7 +34451,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -34501,7 +34508,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -34511,7 +34518,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -34568,7 +34575,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -34578,7 +34585,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -34635,7 +34642,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -34645,7 +34652,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -34702,7 +34709,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -34712,7 +34719,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -34769,7 +34776,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -34779,7 +34786,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -34836,7 +34843,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -34846,7 +34853,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -34903,7 +34910,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -34913,7 +34920,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -34970,7 +34977,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -34980,7 +34987,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -35022,9 +35029,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00400--mixed4b-00409.jpg-->
-    
+
 
 
 
@@ -35439,7 +35446,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -35449,7 +35456,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -35506,7 +35513,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -35516,7 +35523,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -35573,7 +35580,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -35583,7 +35590,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -35640,7 +35647,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -35650,7 +35657,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -35707,7 +35714,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -35717,7 +35724,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -35774,7 +35781,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -35784,7 +35791,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -35841,7 +35848,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -35851,7 +35858,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -35908,7 +35915,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -35918,7 +35925,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -35975,7 +35982,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -35985,7 +35992,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -36042,7 +36049,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -36052,7 +36059,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -36094,9 +36101,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00410--mixed4b-00419.jpg-->
-    
+
 
 
 
@@ -36521,7 +36528,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -36531,7 +36538,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -36588,7 +36595,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -36598,7 +36605,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -36655,7 +36662,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -36665,7 +36672,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -36722,7 +36729,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -36732,7 +36739,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -36789,7 +36796,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -36799,7 +36806,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -36856,7 +36863,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -36866,7 +36873,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -36923,7 +36930,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -36933,7 +36940,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -36990,7 +36997,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -37000,7 +37007,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -37057,7 +37064,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -37067,7 +37074,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -37124,7 +37131,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -37134,7 +37141,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -37176,9 +37183,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00420--mixed4b-00429.jpg-->
-    
+
 
 
 
@@ -37613,7 +37620,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -37623,7 +37630,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -37680,7 +37687,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -37690,7 +37697,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -37747,7 +37754,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -37757,7 +37764,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -37814,7 +37821,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -37824,7 +37831,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -37881,7 +37888,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -37891,7 +37898,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -37948,7 +37955,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -37958,7 +37965,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -38015,7 +38022,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -38025,7 +38032,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -38082,7 +38089,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -38092,7 +38099,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -38149,7 +38156,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -38159,7 +38166,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -38216,7 +38223,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -38226,7 +38233,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -38268,9 +38275,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00430--mixed4b-00439.jpg-->
-    
+
 
 
 
@@ -38715,7 +38722,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -38725,7 +38732,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -38782,7 +38789,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -38792,7 +38799,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -38849,7 +38856,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -38859,7 +38866,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -38916,7 +38923,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -38926,7 +38933,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -38983,7 +38990,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -38993,7 +39000,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -39050,7 +39057,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -39060,7 +39067,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -39117,7 +39124,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -39127,7 +39134,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -39184,7 +39191,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -39194,7 +39201,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -39251,7 +39258,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -39261,7 +39268,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -39318,7 +39325,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -39328,7 +39335,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -39370,9 +39377,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00440--mixed4b-00449.jpg-->
-    
+
 
 
 
@@ -39827,7 +39834,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -39837,7 +39844,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -39894,7 +39901,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -39904,7 +39911,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -39961,7 +39968,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -39971,7 +39978,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -40028,7 +40035,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -40038,7 +40045,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -40095,7 +40102,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -40105,7 +40112,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -40162,7 +40169,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -40172,7 +40179,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -40229,7 +40236,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -40239,7 +40246,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -40296,7 +40303,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -40306,7 +40313,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -40363,7 +40370,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -40373,7 +40380,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -40430,7 +40437,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -40440,7 +40447,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -40482,9 +40489,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00450--mixed4b-00459.jpg-->
-    
+
 
 
 
@@ -40949,7 +40956,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -40959,7 +40966,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -41016,7 +41023,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -41026,7 +41033,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -41083,7 +41090,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -41093,7 +41100,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -41150,7 +41157,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -41160,7 +41167,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -41217,7 +41224,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -41227,7 +41234,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -41284,7 +41291,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -41294,7 +41301,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -41351,7 +41358,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -41361,7 +41368,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -41418,7 +41425,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -41428,7 +41435,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -41485,7 +41492,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -41495,7 +41502,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -41552,7 +41559,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -41562,7 +41569,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -41604,9 +41611,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00460--mixed4b-00469.jpg-->
-    
+
 
 
 
@@ -42081,7 +42088,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -42091,7 +42098,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -42148,7 +42155,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -42158,7 +42165,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -42215,7 +42222,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -42225,7 +42232,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -42282,7 +42289,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -42292,7 +42299,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -42349,7 +42356,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -42359,7 +42366,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -42416,7 +42423,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -42426,7 +42433,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -42483,7 +42490,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -42493,7 +42500,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -42550,7 +42557,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -42560,7 +42567,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -42617,7 +42624,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -42627,7 +42634,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -42684,7 +42691,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -42694,7 +42701,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -42736,9 +42743,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00470--mixed4b-00479.jpg-->
-    
+
 
 
 
@@ -43223,7 +43230,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -43233,7 +43240,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -43290,7 +43297,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -43300,7 +43307,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -43357,7 +43364,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -43367,7 +43374,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -43424,7 +43431,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -43434,7 +43441,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -43491,7 +43498,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -43501,7 +43508,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -43558,7 +43565,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -43568,7 +43575,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -43625,7 +43632,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -43635,7 +43642,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -43692,7 +43699,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -43702,7 +43709,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -43759,7 +43766,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -43769,7 +43776,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -43826,7 +43833,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -43836,7 +43843,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -43878,9 +43885,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00480--mixed4b-00489.jpg-->
-    
+
 
 
 
@@ -44375,7 +44382,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -44385,7 +44392,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -44442,7 +44449,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -44452,7 +44459,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -44509,7 +44516,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -44519,7 +44526,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -44576,7 +44583,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -44586,7 +44593,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -44643,7 +44650,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -44653,7 +44660,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -44710,7 +44717,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -44720,7 +44727,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -44777,7 +44784,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -44787,7 +44794,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -44844,7 +44851,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -44854,7 +44861,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -44911,7 +44918,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -44921,7 +44928,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -44978,7 +44985,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -44988,7 +44995,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -45030,9 +45037,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00490--mixed4b-00499.jpg-->
-    
+
 
 
 
@@ -45537,7 +45544,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -45547,7 +45554,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -45604,7 +45611,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -45614,7 +45621,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -45671,7 +45678,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -45681,7 +45688,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -45738,7 +45745,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -45748,7 +45755,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -45805,7 +45812,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -45815,7 +45822,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -45872,7 +45879,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -45882,7 +45889,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -45939,7 +45946,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -45949,7 +45956,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -46006,7 +46013,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -46016,7 +46023,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -46073,7 +46080,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -46083,7 +46090,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -46140,7 +46147,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -46150,7 +46157,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -46192,9 +46199,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00500--mixed4b-00509.jpg-->
-    
+
 
 
 
@@ -46709,7 +46716,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -46719,7 +46726,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -46776,7 +46783,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -46786,7 +46793,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -46843,7 +46850,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -46853,7 +46860,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -46910,7 +46917,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -46920,7 +46927,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -46977,7 +46984,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -46987,7 +46994,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -47044,7 +47051,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -47054,7 +47061,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -47111,7 +47118,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -47121,7 +47128,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -47178,7 +47185,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -47188,7 +47195,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -47245,7 +47252,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -47255,7 +47262,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -47312,7 +47319,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -47322,7 +47329,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -47364,9 +47371,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4b-00510--mixed4b-00511.jpg-->
-    
+
 
 
 
@@ -47891,7 +47898,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -47901,7 +47908,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -47958,7 +47965,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -47968,7 +47975,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -48010,9 +48017,8 @@
       </div>
       </d-figure>
       </li>
-  
+
   </ul>
   </d-article>
   <distill-footer></distill-footer>
 </body>
-  

--- a/public/appendix/googlenet/4c.html
+++ b/public/appendix/googlenet/4c.html
@@ -5,21 +5,21 @@
   <meta charset="utf8">
   <script src="https://distill.pub/template.v2.js"></script>
   <style>
-  
+
     d-article {
       line-height: 1em;
     }
-    
+
     d-byline,
     d-appendix {
       display: none;
     }
-  
+
     h4 {
       display: block;
       width: 100%;
     }
-    
+
     d-figure {
       display: flex;
       flex-flow: row;
@@ -31,7 +31,7 @@
       margin-bottom: 1em;
       justify-content: center;
     }
-    
+
     .positive,
     .negative {
       display: flex;
@@ -40,7 +40,7 @@
       align-content: flex-start;
       max-width: 370px;
     }
-    
+
     .positive {
       padding-left: 1em;
       padding-right: 1em;
@@ -50,14 +50,14 @@
       border-right: 1px solid rgba(0,0,0,0.1);
       justify-content: space-between;
     }
-    
+
     .figcaption {
       display: block;
       color: rgba(0, 0, 0, 0.6);
       font-size: 12px;
       line-height: 1.5em;
     }
-    
+
     .diversity {
       display: flex;
       flex-flow: row;
@@ -65,61 +65,61 @@
       width: 148px;
       height: 147px
     }
-    
+
     .diversity > div {
       zoom: 0.496598639;
     }
-    
+
     .channel {
       margin-right: 1em;
     }
-    
+
     .channels {
       grid-column: screen;
       list-style: none;
       padding-left: 0;
     }
-    
+
     .channels li {
       contain: content;
       overflow: hidden;
     }
-    
+
     .sprite {
       display: inline-block;
       margin: 1px;
       width: 147px;
       height: 147px;
     }
-    
+
     .sprite.neuron {
       background-position-x: 0px;
     }
-    
+
     .sprite.channel {
       background-position-x: -147px;
     }
-    
+
     .sprite.channel-negative {
       background-position-x: -294px;
     }
-    
+
     .sprite.channel-diversity-0 {
       background-position-x: -441px;
     }
-    
+
     .sprite.channel-diversity-1 {
       background-position-x: -588px;
     }
-    
+
     .sprite.channel-diversity-2 {
       background-position-x: -735px;
     }
-    
+
     .sprite.channel-diversity-3 {
       background-position-x: -882px;
     }
-    
+
     .dataset-examples {
       display: flex;
       flex-flow: row;
@@ -127,7 +127,7 @@
       width: 375px;
       height: 147px
     }
-    
+
     .dataset-examples .sprite {
       height: 73px;
       width: 73px;
@@ -136,16 +136,16 @@
       margin-bottom: 0;
       margin-right: 0;
     }
-    
-    
+
+
       .channels .sprite.dataset-index-0 {
         background-position-x: -1029px !important;
       }
-      
+
       .channels .sprite.index-0 {
         background-position-y: -0px;
       }
-      
+
       .channels .dataset-negative .sprite.index-0 {
         background-position-y: -74px !important;
       }
@@ -153,11 +153,11 @@
       .channels .sprite.dataset-index-1 {
         background-position-x: -1103px !important;
       }
-      
+
       .channels .sprite.index-1 {
         background-position-y: -147px;
       }
-      
+
       .channels .dataset-negative .sprite.index-1 {
         background-position-y: -221px !important;
       }
@@ -165,11 +165,11 @@
       .channels .sprite.dataset-index-2 {
         background-position-x: -1177px !important;
       }
-      
+
       .channels .sprite.index-2 {
         background-position-y: -294px;
       }
-      
+
       .channels .dataset-negative .sprite.index-2 {
         background-position-y: -368px !important;
       }
@@ -177,11 +177,11 @@
       .channels .sprite.dataset-index-3 {
         background-position-x: -1251px !important;
       }
-      
+
       .channels .sprite.index-3 {
         background-position-y: -441px;
       }
-      
+
       .channels .dataset-negative .sprite.index-3 {
         background-position-y: -515px !important;
       }
@@ -189,11 +189,11 @@
       .channels .sprite.dataset-index-4 {
         background-position-x: -1325px !important;
       }
-      
+
       .channels .sprite.index-4 {
         background-position-y: -588px;
       }
-      
+
       .channels .dataset-negative .sprite.index-4 {
         background-position-y: -662px !important;
       }
@@ -201,11 +201,11 @@
       .channels .sprite.dataset-index-5 {
         background-position-x: -1399px !important;
       }
-      
+
       .channels .sprite.index-5 {
         background-position-y: -735px;
       }
-      
+
       .channels .dataset-negative .sprite.index-5 {
         background-position-y: -809px !important;
       }
@@ -213,11 +213,11 @@
       .channels .sprite.dataset-index-6 {
         background-position-x: -1473px !important;
       }
-      
+
       .channels .sprite.index-6 {
         background-position-y: -882px;
       }
-      
+
       .channels .dataset-negative .sprite.index-6 {
         background-position-y: -956px !important;
       }
@@ -225,11 +225,11 @@
       .channels .sprite.dataset-index-7 {
         background-position-x: -1547px !important;
       }
-      
+
       .channels .sprite.index-7 {
         background-position-y: -1029px;
       }
-      
+
       .channels .dataset-negative .sprite.index-7 {
         background-position-y: -1103px !important;
       }
@@ -237,11 +237,11 @@
       .channels .sprite.dataset-index-8 {
         background-position-x: -1621px !important;
       }
-      
+
       .channels .sprite.index-8 {
         background-position-y: -1176px;
       }
-      
+
       .channels .dataset-negative .sprite.index-8 {
         background-position-y: -1250px !important;
       }
@@ -249,20 +249,20 @@
       .channels .sprite.dataset-index-9 {
         background-position-x: -1695px !important;
       }
-      
+
       .channels .sprite.index-9 {
         background-position-y: -1323px;
       }
-      
+
       .channels .dataset-negative .sprite.index-9 {
         background-position-y: -1397px !important;
       }
-    
-    
+
+
     .article-nav {
       grid-column: page;
     }
-    
+
     .navlist li {
       display: inline;
       list-style-type: none;
@@ -300,10 +300,10 @@
     <h1>Layer 4c</h1>
   </d-title>
   <d-article>
-  
+
   <nav class="article-nav">
-  
-    
+
+
     <ul class="navlist">
       <li><a href="https://distill.pub/2017/feature-visualization/appendix/">Appendix overview</a></li>
       <li><a href="https://distill.pub/2017/feature-visualization/">Main article</a></li>
@@ -322,7 +322,7 @@
         <a href="4b.html">Layer 4b</a>
       </li>
       <li>
-        <a href="4c.html">Layer 4c</a>
+        <a href="4c.html"><b>Layer 4c</b></a>
       </li>
       <li>
         <a href="4d.html">Layer 4d</a>
@@ -337,14 +337,21 @@
         <a href="5b.html">Layer 5b</a>
       </li>
     </ul>
-  
+
+    <ul class="navlist">
+      <li> <a href="4c.html#4c-0">4c 1x1</a> <span style="color: #777;">(0:128)</span> </li>
+      <li> <a href="4c.html#4c-128">4c 3x3</a> <span style="color: #777;">(128:384)</span> </li>
+      <li> <a href="4c.html#4c-384">4c 5x5</a> <span style="color: #777;">(384:448)</span> </li>
+      <li> <a href="4c.html#4c-448">4c pool</a> <span style="color: #777;">(448:512)</span> </li>
+    </ul>
+
   </nav>
-  
+
   <hr style="margin-top: 20px;"/>
-  
+
   <ul class="channels">
     <!--mixed4c-00000--mixed4c-00009.jpg-->
-    
+
       <li id="channel-0">
       <d-figure id="4c-0">
       <style data-img-src="images/mixed4c-00000--mixed4c-00009.jpg" data-channel="0"></style>
@@ -359,7 +366,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -369,7 +376,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -426,7 +433,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -436,7 +443,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -493,7 +500,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -503,7 +510,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -560,7 +567,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -570,7 +577,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -627,7 +634,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -637,7 +644,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -694,7 +701,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -704,7 +711,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -761,7 +768,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -771,7 +778,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -828,7 +835,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -838,7 +845,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -895,7 +902,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -905,7 +912,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -962,7 +969,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -972,7 +979,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -1014,9 +1021,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00010--mixed4c-00019.jpg-->
-    
+
 
 
 
@@ -1041,7 +1048,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -1051,7 +1058,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -1108,7 +1115,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -1118,7 +1125,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -1175,7 +1182,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -1185,7 +1192,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -1242,7 +1249,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -1252,7 +1259,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -1309,7 +1316,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -1319,7 +1326,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -1376,7 +1383,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -1386,7 +1393,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -1443,7 +1450,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -1453,7 +1460,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -1510,7 +1517,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -1520,7 +1527,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -1577,7 +1584,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -1587,7 +1594,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -1644,7 +1651,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -1654,7 +1661,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -1696,9 +1703,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00020--mixed4c-00029.jpg-->
-    
+
 
 
 
@@ -1733,7 +1740,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -1743,7 +1750,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -1800,7 +1807,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -1810,7 +1817,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -1867,7 +1874,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -1877,7 +1884,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -1934,7 +1941,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -1944,7 +1951,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -2001,7 +2008,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -2011,7 +2018,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -2068,7 +2075,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -2078,7 +2085,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -2135,7 +2142,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -2145,7 +2152,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -2202,7 +2209,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -2212,7 +2219,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -2269,7 +2276,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -2279,7 +2286,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -2336,7 +2343,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -2346,7 +2353,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -2388,9 +2395,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00030--mixed4c-00039.jpg-->
-    
+
 
 
 
@@ -2435,7 +2442,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -2445,7 +2452,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -2502,7 +2509,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -2512,7 +2519,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -2569,7 +2576,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -2579,7 +2586,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -2636,7 +2643,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -2646,7 +2653,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -2703,7 +2710,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -2713,7 +2720,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -2770,7 +2777,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -2780,7 +2787,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -2837,7 +2844,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -2847,7 +2854,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -2904,7 +2911,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -2914,7 +2921,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -2971,7 +2978,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -2981,7 +2988,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -3038,7 +3045,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -3048,7 +3055,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -3090,9 +3097,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00040--mixed4c-00049.jpg-->
-    
+
 
 
 
@@ -3147,7 +3154,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -3157,7 +3164,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -3214,7 +3221,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -3224,7 +3231,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -3281,7 +3288,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -3291,7 +3298,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -3348,7 +3355,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -3358,7 +3365,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -3415,7 +3422,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -3425,7 +3432,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -3482,7 +3489,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -3492,7 +3499,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -3549,7 +3556,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -3559,7 +3566,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -3616,7 +3623,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -3626,7 +3633,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -3683,7 +3690,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -3693,7 +3700,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -3750,7 +3757,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -3760,7 +3767,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -3802,9 +3809,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00050--mixed4c-00059.jpg-->
-    
+
 
 
 
@@ -3869,7 +3876,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -3879,7 +3886,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -3936,7 +3943,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -3946,7 +3953,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -4003,7 +4010,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -4013,7 +4020,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -4070,7 +4077,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -4080,7 +4087,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -4137,7 +4144,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -4147,7 +4154,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -4204,7 +4211,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -4214,7 +4221,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -4271,7 +4278,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -4281,7 +4288,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -4338,7 +4345,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -4348,7 +4355,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -4405,7 +4412,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -4415,7 +4422,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -4472,7 +4479,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -4482,7 +4489,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -4524,9 +4531,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00060--mixed4c-00069.jpg-->
-    
+
 
 
 
@@ -4601,7 +4608,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -4611,7 +4618,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -4668,7 +4675,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -4678,7 +4685,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -4735,7 +4742,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -4745,7 +4752,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -4802,7 +4809,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -4812,7 +4819,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -4869,7 +4876,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -4879,7 +4886,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -4936,7 +4943,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -4946,7 +4953,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -5003,7 +5010,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -5013,7 +5020,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -5070,7 +5077,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -5080,7 +5087,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -5137,7 +5144,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -5147,7 +5154,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -5204,7 +5211,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -5214,7 +5221,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -5256,9 +5263,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00070--mixed4c-00079.jpg-->
-    
+
 
 
 
@@ -5343,7 +5350,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -5353,7 +5360,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -5410,7 +5417,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -5420,7 +5427,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -5477,7 +5484,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -5487,7 +5494,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -5544,7 +5551,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -5554,7 +5561,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -5611,7 +5618,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -5621,7 +5628,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -5678,7 +5685,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -5688,7 +5695,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -5745,7 +5752,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -5755,7 +5762,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -5812,7 +5819,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -5822,7 +5829,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -5879,7 +5886,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -5889,7 +5896,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -5946,7 +5953,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -5956,7 +5963,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -5998,9 +6005,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00080--mixed4c-00089.jpg-->
-    
+
 
 
 
@@ -6095,7 +6102,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -6105,7 +6112,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -6162,7 +6169,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -6172,7 +6179,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -6229,7 +6236,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -6239,7 +6246,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -6296,7 +6303,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -6306,7 +6313,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -6363,7 +6370,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -6373,7 +6380,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -6430,7 +6437,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -6440,7 +6447,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -6497,7 +6504,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -6507,7 +6514,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -6564,7 +6571,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -6574,7 +6581,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -6631,7 +6638,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -6641,7 +6648,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -6698,7 +6705,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -6708,7 +6715,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -6750,9 +6757,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00090--mixed4c-00099.jpg-->
-    
+
 
 
 
@@ -6857,7 +6864,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -6867,7 +6874,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -6924,7 +6931,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -6934,7 +6941,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -6991,7 +6998,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -7001,7 +7008,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -7058,7 +7065,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -7068,7 +7075,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -7125,7 +7132,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -7135,7 +7142,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -7192,7 +7199,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -7202,7 +7209,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -7259,7 +7266,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -7269,7 +7276,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -7326,7 +7333,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -7336,7 +7343,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -7393,7 +7400,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -7403,7 +7410,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -7460,7 +7467,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -7470,7 +7477,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -7512,9 +7519,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00100--mixed4c-00109.jpg-->
-    
+
 
 
 
@@ -7629,7 +7636,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -7639,7 +7646,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -7696,7 +7703,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -7706,7 +7713,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -7763,7 +7770,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -7773,7 +7780,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -7830,7 +7837,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -7840,7 +7847,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -7897,7 +7904,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -7907,7 +7914,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -7964,7 +7971,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -7974,7 +7981,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -8031,7 +8038,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -8041,7 +8048,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -8098,7 +8105,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -8108,7 +8115,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -8165,7 +8172,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -8175,7 +8182,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -8232,7 +8239,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -8242,7 +8249,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -8284,9 +8291,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00110--mixed4c-00119.jpg-->
-    
+
 
 
 
@@ -8411,7 +8418,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -8421,7 +8428,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -8478,7 +8485,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -8488,7 +8495,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -8545,7 +8552,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -8555,7 +8562,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -8612,7 +8619,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -8622,7 +8629,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -8679,7 +8686,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -8689,7 +8696,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -8746,7 +8753,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -8756,7 +8763,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -8813,7 +8820,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -8823,7 +8830,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -8880,7 +8887,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -8890,7 +8897,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -8947,7 +8954,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -8957,7 +8964,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -9014,7 +9021,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -9024,7 +9031,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -9066,9 +9073,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00120--mixed4c-00129.jpg-->
-    
+
 
 
 
@@ -9203,7 +9210,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -9213,7 +9220,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -9270,7 +9277,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -9280,7 +9287,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -9337,7 +9344,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -9347,7 +9354,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -9404,7 +9411,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -9414,7 +9421,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -9471,7 +9478,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -9481,7 +9488,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -9538,7 +9545,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -9548,7 +9555,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -9605,7 +9612,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -9615,7 +9622,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -9672,7 +9679,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -9682,7 +9689,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -9739,7 +9746,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -9749,7 +9756,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -9806,7 +9813,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -9816,7 +9823,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -9858,9 +9865,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00130--mixed4c-00139.jpg-->
-    
+
 
 
 
@@ -10005,7 +10012,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -10015,7 +10022,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -10072,7 +10079,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -10082,7 +10089,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -10139,7 +10146,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -10149,7 +10156,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -10206,7 +10213,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -10216,7 +10223,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -10273,7 +10280,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -10283,7 +10290,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -10340,7 +10347,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -10350,7 +10357,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -10407,7 +10414,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -10417,7 +10424,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -10474,7 +10481,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -10484,7 +10491,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -10541,7 +10548,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -10551,7 +10558,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -10608,7 +10615,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -10618,7 +10625,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -10660,9 +10667,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00140--mixed4c-00149.jpg-->
-    
+
 
 
 
@@ -10817,7 +10824,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -10827,7 +10834,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -10884,7 +10891,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -10894,7 +10901,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -10951,7 +10958,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -10961,7 +10968,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -11018,7 +11025,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -11028,7 +11035,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -11085,7 +11092,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -11095,7 +11102,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -11152,7 +11159,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -11162,7 +11169,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -11219,7 +11226,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -11229,7 +11236,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -11286,7 +11293,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -11296,7 +11303,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -11353,7 +11360,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -11363,7 +11370,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -11420,7 +11427,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -11430,7 +11437,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -11472,9 +11479,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00150--mixed4c-00159.jpg-->
-    
+
 
 
 
@@ -11639,7 +11646,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -11649,7 +11656,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -11706,7 +11713,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -11716,7 +11723,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -11773,7 +11780,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -11783,7 +11790,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -11840,7 +11847,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -11850,7 +11857,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -11907,7 +11914,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -11917,7 +11924,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -11974,7 +11981,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -11984,7 +11991,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -12041,7 +12048,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -12051,7 +12058,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -12108,7 +12115,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -12118,7 +12125,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -12175,7 +12182,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -12185,7 +12192,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -12242,7 +12249,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -12252,7 +12259,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -12294,9 +12301,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00160--mixed4c-00169.jpg-->
-    
+
 
 
 
@@ -12471,7 +12478,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -12481,7 +12488,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -12538,7 +12545,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -12548,7 +12555,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -12605,7 +12612,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -12615,7 +12622,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -12672,7 +12679,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -12682,7 +12689,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -12739,7 +12746,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -12749,7 +12756,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -12806,7 +12813,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -12816,7 +12823,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -12873,7 +12880,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -12883,7 +12890,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -12940,7 +12947,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -12950,7 +12957,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -13007,7 +13014,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -13017,7 +13024,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -13074,7 +13081,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -13084,7 +13091,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -13126,9 +13133,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00170--mixed4c-00179.jpg-->
-    
+
 
 
 
@@ -13313,7 +13320,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -13323,7 +13330,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -13380,7 +13387,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -13390,7 +13397,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -13447,7 +13454,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -13457,7 +13464,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -13514,7 +13521,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -13524,7 +13531,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -13581,7 +13588,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -13591,7 +13598,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -13648,7 +13655,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -13658,7 +13665,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -13715,7 +13722,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -13725,7 +13732,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -13782,7 +13789,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -13792,7 +13799,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -13849,7 +13856,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -13859,7 +13866,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -13916,7 +13923,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -13926,7 +13933,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -13968,9 +13975,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00180--mixed4c-00189.jpg-->
-    
+
 
 
 
@@ -14165,7 +14172,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -14175,7 +14182,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -14232,7 +14239,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -14242,7 +14249,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -14299,7 +14306,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -14309,7 +14316,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -14366,7 +14373,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -14376,7 +14383,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -14433,7 +14440,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -14443,7 +14450,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -14500,7 +14507,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -14510,7 +14517,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -14567,7 +14574,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -14577,7 +14584,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -14634,7 +14641,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -14644,7 +14651,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -14701,7 +14708,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -14711,7 +14718,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -14768,7 +14775,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -14778,7 +14785,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -14820,9 +14827,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00190--mixed4c-00199.jpg-->
-    
+
 
 
 
@@ -15027,7 +15034,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -15037,7 +15044,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -15094,7 +15101,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -15104,7 +15111,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -15161,7 +15168,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -15171,7 +15178,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -15228,7 +15235,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -15238,7 +15245,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -15295,7 +15302,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -15305,7 +15312,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -15362,7 +15369,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -15372,7 +15379,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -15429,7 +15436,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -15439,7 +15446,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -15496,7 +15503,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -15506,7 +15513,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -15563,7 +15570,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -15573,7 +15580,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -15630,7 +15637,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -15640,7 +15647,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -15682,9 +15689,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00200--mixed4c-00209.jpg-->
-    
+
 
 
 
@@ -15899,7 +15906,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -15909,7 +15916,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -15966,7 +15973,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -15976,7 +15983,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -16033,7 +16040,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -16043,7 +16050,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -16100,7 +16107,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -16110,7 +16117,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -16167,7 +16174,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -16177,7 +16184,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -16234,7 +16241,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -16244,7 +16251,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -16301,7 +16308,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -16311,7 +16318,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -16368,7 +16375,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -16378,7 +16385,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -16435,7 +16442,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -16445,7 +16452,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -16502,7 +16509,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -16512,7 +16519,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -16554,9 +16561,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00210--mixed4c-00219.jpg-->
-    
+
 
 
 
@@ -16781,7 +16788,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -16791,7 +16798,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -16848,7 +16855,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -16858,7 +16865,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -16915,7 +16922,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -16925,7 +16932,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -16982,7 +16989,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -16992,7 +16999,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -17049,7 +17056,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -17059,7 +17066,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -17116,7 +17123,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -17126,7 +17133,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -17183,7 +17190,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -17193,7 +17200,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -17250,7 +17257,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -17260,7 +17267,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -17317,7 +17324,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -17327,7 +17334,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -17384,7 +17391,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -17394,7 +17401,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -17436,9 +17443,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00220--mixed4c-00229.jpg-->
-    
+
 
 
 
@@ -17673,7 +17680,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -17683,7 +17690,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -17740,7 +17747,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -17750,7 +17757,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -17807,7 +17814,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -17817,7 +17824,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -17874,7 +17881,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -17884,7 +17891,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -17941,7 +17948,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -17951,7 +17958,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -18008,7 +18015,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -18018,7 +18025,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -18075,7 +18082,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -18085,7 +18092,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -18142,7 +18149,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -18152,7 +18159,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -18209,7 +18216,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -18219,7 +18226,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -18276,7 +18283,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -18286,7 +18293,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -18328,9 +18335,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00230--mixed4c-00239.jpg-->
-    
+
 
 
 
@@ -18575,7 +18582,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -18585,7 +18592,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -18642,7 +18649,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -18652,7 +18659,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -18709,7 +18716,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -18719,7 +18726,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -18776,7 +18783,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -18786,7 +18793,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -18843,7 +18850,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -18853,7 +18860,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -18910,7 +18917,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -18920,7 +18927,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -18977,7 +18984,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -18987,7 +18994,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -19044,7 +19051,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -19054,7 +19061,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -19111,7 +19118,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -19121,7 +19128,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -19178,7 +19185,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -19188,7 +19195,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -19230,9 +19237,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00240--mixed4c-00249.jpg-->
-    
+
 
 
 
@@ -19487,7 +19494,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -19497,7 +19504,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -19554,7 +19561,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -19564,7 +19571,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -19621,7 +19628,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -19631,7 +19638,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -19688,7 +19695,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -19698,7 +19705,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -19755,7 +19762,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -19765,7 +19772,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -19822,7 +19829,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -19832,7 +19839,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -19889,7 +19896,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -19899,7 +19906,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -19956,7 +19963,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -19966,7 +19973,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -20023,7 +20030,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -20033,7 +20040,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -20090,7 +20097,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -20100,7 +20107,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -20142,9 +20149,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00250--mixed4c-00259.jpg-->
-    
+
 
 
 
@@ -20409,7 +20416,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -20419,7 +20426,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -20476,7 +20483,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -20486,7 +20493,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -20543,7 +20550,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -20553,7 +20560,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -20610,7 +20617,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -20620,7 +20627,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -20677,7 +20684,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -20687,7 +20694,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -20744,7 +20751,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -20754,7 +20761,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -20811,7 +20818,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -20821,7 +20828,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -20878,7 +20885,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -20888,7 +20895,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -20945,7 +20952,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -20955,7 +20962,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -21012,7 +21019,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -21022,7 +21029,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -21064,9 +21071,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00260--mixed4c-00269.jpg-->
-    
+
 
 
 
@@ -21341,7 +21348,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -21351,7 +21358,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -21408,7 +21415,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -21418,7 +21425,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -21475,7 +21482,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -21485,7 +21492,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -21542,7 +21549,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -21552,7 +21559,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -21609,7 +21616,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -21619,7 +21626,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -21676,7 +21683,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -21686,7 +21693,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -21743,7 +21750,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -21753,7 +21760,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -21810,7 +21817,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -21820,7 +21827,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -21877,7 +21884,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -21887,7 +21894,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -21944,7 +21951,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -21954,7 +21961,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -21996,9 +22003,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00270--mixed4c-00279.jpg-->
-    
+
 
 
 
@@ -22283,7 +22290,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -22293,7 +22300,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -22350,7 +22357,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -22360,7 +22367,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -22417,7 +22424,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -22427,7 +22434,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -22484,7 +22491,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -22494,7 +22501,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -22551,7 +22558,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -22561,7 +22568,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -22618,7 +22625,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -22628,7 +22635,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -22685,7 +22692,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -22695,7 +22702,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -22752,7 +22759,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -22762,7 +22769,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -22819,7 +22826,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -22829,7 +22836,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -22886,7 +22893,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -22896,7 +22903,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -22938,9 +22945,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00280--mixed4c-00289.jpg-->
-    
+
 
 
 
@@ -23235,7 +23242,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -23245,7 +23252,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -23302,7 +23309,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -23312,7 +23319,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -23369,7 +23376,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -23379,7 +23386,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -23436,7 +23443,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -23446,7 +23453,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -23503,7 +23510,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -23513,7 +23520,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -23570,7 +23577,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -23580,7 +23587,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -23637,7 +23644,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -23647,7 +23654,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -23704,7 +23711,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -23714,7 +23721,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -23771,7 +23778,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -23781,7 +23788,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -23838,7 +23845,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -23848,7 +23855,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -23890,9 +23897,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00290--mixed4c-00299.jpg-->
-    
+
 
 
 
@@ -24197,7 +24204,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -24207,7 +24214,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -24264,7 +24271,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -24274,7 +24281,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -24331,7 +24338,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -24341,7 +24348,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -24398,7 +24405,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -24408,7 +24415,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -24465,7 +24472,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -24475,7 +24482,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -24532,7 +24539,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -24542,7 +24549,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -24599,7 +24606,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -24609,7 +24616,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -24666,7 +24673,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -24676,7 +24683,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -24733,7 +24740,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -24743,7 +24750,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -24800,7 +24807,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -24810,7 +24817,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -24852,9 +24859,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00300--mixed4c-00309.jpg-->
-    
+
 
 
 
@@ -25169,7 +25176,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -25179,7 +25186,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -25236,7 +25243,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -25246,7 +25253,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -25303,7 +25310,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -25313,7 +25320,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -25370,7 +25377,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -25380,7 +25387,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -25437,7 +25444,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -25447,7 +25454,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -25504,7 +25511,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -25514,7 +25521,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -25571,7 +25578,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -25581,7 +25588,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -25638,7 +25645,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -25648,7 +25655,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -25705,7 +25712,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -25715,7 +25722,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -25772,7 +25779,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -25782,7 +25789,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -25824,9 +25831,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00310--mixed4c-00319.jpg-->
-    
+
 
 
 
@@ -26151,7 +26158,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -26161,7 +26168,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -26218,7 +26225,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -26228,7 +26235,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -26285,7 +26292,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -26295,7 +26302,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -26352,7 +26359,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -26362,7 +26369,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -26419,7 +26426,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -26429,7 +26436,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -26486,7 +26493,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -26496,7 +26503,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -26553,7 +26560,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -26563,7 +26570,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -26620,7 +26627,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -26630,7 +26637,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -26687,7 +26694,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -26697,7 +26704,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -26754,7 +26761,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -26764,7 +26771,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -26806,9 +26813,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00320--mixed4c-00329.jpg-->
-    
+
 
 
 
@@ -27143,7 +27150,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -27153,7 +27160,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -27210,7 +27217,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -27220,7 +27227,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -27277,7 +27284,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -27287,7 +27294,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -27344,7 +27351,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -27354,7 +27361,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -27411,7 +27418,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -27421,7 +27428,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -27478,7 +27485,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -27488,7 +27495,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -27545,7 +27552,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -27555,7 +27562,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -27612,7 +27619,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -27622,7 +27629,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -27679,7 +27686,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -27689,7 +27696,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -27746,7 +27753,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -27756,7 +27763,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -27798,9 +27805,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00330--mixed4c-00339.jpg-->
-    
+
 
 
 
@@ -28145,7 +28152,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -28155,7 +28162,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -28212,7 +28219,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -28222,7 +28229,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -28279,7 +28286,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -28289,7 +28296,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -28346,7 +28353,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -28356,7 +28363,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -28413,7 +28420,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -28423,7 +28430,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -28480,7 +28487,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -28490,7 +28497,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -28547,7 +28554,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -28557,7 +28564,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -28614,7 +28621,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -28624,7 +28631,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -28681,7 +28688,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -28691,7 +28698,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -28748,7 +28755,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -28758,7 +28765,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -28800,9 +28807,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00340--mixed4c-00349.jpg-->
-    
+
 
 
 
@@ -29157,7 +29164,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -29167,7 +29174,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -29224,7 +29231,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -29234,7 +29241,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -29291,7 +29298,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -29301,7 +29308,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -29358,7 +29365,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -29368,7 +29375,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -29425,7 +29432,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -29435,7 +29442,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -29492,7 +29499,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -29502,7 +29509,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -29559,7 +29566,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -29569,7 +29576,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -29626,7 +29633,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -29636,7 +29643,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -29693,7 +29700,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -29703,7 +29710,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -29760,7 +29767,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -29770,7 +29777,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -29812,9 +29819,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00350--mixed4c-00359.jpg-->
-    
+
 
 
 
@@ -30179,7 +30186,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -30189,7 +30196,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -30246,7 +30253,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -30256,7 +30263,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -30313,7 +30320,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -30323,7 +30330,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -30380,7 +30387,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -30390,7 +30397,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -30447,7 +30454,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -30457,7 +30464,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -30514,7 +30521,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -30524,7 +30531,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -30581,7 +30588,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -30591,7 +30598,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -30648,7 +30655,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -30658,7 +30665,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -30715,7 +30722,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -30725,7 +30732,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -30782,7 +30789,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -30792,7 +30799,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -30834,9 +30841,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00360--mixed4c-00369.jpg-->
-    
+
 
 
 
@@ -31211,7 +31218,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -31221,7 +31228,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -31278,7 +31285,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -31288,7 +31295,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -31345,7 +31352,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -31355,7 +31362,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -31412,7 +31419,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -31422,7 +31429,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -31479,7 +31486,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -31489,7 +31496,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -31546,7 +31553,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -31556,7 +31563,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -31613,7 +31620,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -31623,7 +31630,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -31680,7 +31687,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -31690,7 +31697,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -31747,7 +31754,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -31757,7 +31764,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -31814,7 +31821,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -31824,7 +31831,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -31866,9 +31873,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00370--mixed4c-00379.jpg-->
-    
+
 
 
 
@@ -32253,7 +32260,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -32263,7 +32270,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -32320,7 +32327,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -32330,7 +32337,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -32387,7 +32394,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -32397,7 +32404,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -32454,7 +32461,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -32464,7 +32471,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -32521,7 +32528,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -32531,7 +32538,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -32588,7 +32595,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -32598,7 +32605,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -32655,7 +32662,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -32665,7 +32672,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -32722,7 +32729,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -32732,7 +32739,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -32789,7 +32796,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -32799,7 +32806,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -32856,7 +32863,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -32866,7 +32873,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -32908,9 +32915,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00380--mixed4c-00389.jpg-->
-    
+
 
 
 
@@ -33305,7 +33312,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -33315,7 +33322,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -33372,7 +33379,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -33382,7 +33389,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -33439,7 +33446,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -33449,7 +33456,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -33506,7 +33513,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -33516,7 +33523,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -33573,7 +33580,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -33583,7 +33590,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -33640,7 +33647,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -33650,7 +33657,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -33707,7 +33714,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -33717,7 +33724,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -33774,7 +33781,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -33784,7 +33791,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -33841,7 +33848,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -33851,7 +33858,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -33908,7 +33915,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -33918,7 +33925,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -33960,9 +33967,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00390--mixed4c-00399.jpg-->
-    
+
 
 
 
@@ -34367,7 +34374,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -34377,7 +34384,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -34434,7 +34441,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -34444,7 +34451,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -34501,7 +34508,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -34511,7 +34518,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -34568,7 +34575,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -34578,7 +34585,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -34635,7 +34642,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -34645,7 +34652,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -34702,7 +34709,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -34712,7 +34719,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -34769,7 +34776,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -34779,7 +34786,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -34836,7 +34843,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -34846,7 +34853,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -34903,7 +34910,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -34913,7 +34920,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -34970,7 +34977,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -34980,7 +34987,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -35022,9 +35029,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00400--mixed4c-00409.jpg-->
-    
+
 
 
 
@@ -35439,7 +35446,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -35449,7 +35456,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -35506,7 +35513,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -35516,7 +35523,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -35573,7 +35580,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -35583,7 +35590,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -35640,7 +35647,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -35650,7 +35657,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -35707,7 +35714,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -35717,7 +35724,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -35774,7 +35781,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -35784,7 +35791,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -35841,7 +35848,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -35851,7 +35858,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -35908,7 +35915,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -35918,7 +35925,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -35975,7 +35982,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -35985,7 +35992,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -36042,7 +36049,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -36052,7 +36059,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -36094,9 +36101,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00410--mixed4c-00419.jpg-->
-    
+
 
 
 
@@ -36521,7 +36528,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -36531,7 +36538,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -36588,7 +36595,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -36598,7 +36605,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -36655,7 +36662,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -36665,7 +36672,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -36722,7 +36729,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -36732,7 +36739,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -36789,7 +36796,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -36799,7 +36806,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -36856,7 +36863,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -36866,7 +36873,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -36923,7 +36930,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -36933,7 +36940,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -36990,7 +36997,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -37000,7 +37007,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -37057,7 +37064,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -37067,7 +37074,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -37124,7 +37131,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -37134,7 +37141,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -37176,9 +37183,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00420--mixed4c-00429.jpg-->
-    
+
 
 
 
@@ -37613,7 +37620,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -37623,7 +37630,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -37680,7 +37687,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -37690,7 +37697,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -37747,7 +37754,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -37757,7 +37764,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -37814,7 +37821,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -37824,7 +37831,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -37881,7 +37888,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -37891,7 +37898,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -37948,7 +37955,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -37958,7 +37965,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -38015,7 +38022,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -38025,7 +38032,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -38082,7 +38089,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -38092,7 +38099,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -38149,7 +38156,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -38159,7 +38166,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -38216,7 +38223,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -38226,7 +38233,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -38268,9 +38275,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00430--mixed4c-00439.jpg-->
-    
+
 
 
 
@@ -38715,7 +38722,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -38725,7 +38732,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -38782,7 +38789,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -38792,7 +38799,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -38849,7 +38856,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -38859,7 +38866,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -38916,7 +38923,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -38926,7 +38933,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -38983,7 +38990,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -38993,7 +39000,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -39050,7 +39057,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -39060,7 +39067,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -39117,7 +39124,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -39127,7 +39134,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -39184,7 +39191,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -39194,7 +39201,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -39251,7 +39258,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -39261,7 +39268,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -39318,7 +39325,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -39328,7 +39335,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -39370,9 +39377,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00440--mixed4c-00449.jpg-->
-    
+
 
 
 
@@ -39827,7 +39834,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -39837,7 +39844,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -39894,7 +39901,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -39904,7 +39911,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -39961,7 +39968,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -39971,7 +39978,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -40028,7 +40035,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -40038,7 +40045,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -40095,7 +40102,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -40105,7 +40112,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -40162,7 +40169,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -40172,7 +40179,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -40229,7 +40236,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -40239,7 +40246,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -40296,7 +40303,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -40306,7 +40313,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -40363,7 +40370,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -40373,7 +40380,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -40430,7 +40437,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -40440,7 +40447,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -40482,9 +40489,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00450--mixed4c-00459.jpg-->
-    
+
 
 
 
@@ -40949,7 +40956,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -40959,7 +40966,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -41016,7 +41023,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -41026,7 +41033,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -41083,7 +41090,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -41093,7 +41100,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -41150,7 +41157,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -41160,7 +41167,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -41217,7 +41224,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -41227,7 +41234,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -41284,7 +41291,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -41294,7 +41301,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -41351,7 +41358,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -41361,7 +41368,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -41418,7 +41425,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -41428,7 +41435,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -41485,7 +41492,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -41495,7 +41502,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -41552,7 +41559,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -41562,7 +41569,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -41604,9 +41611,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00460--mixed4c-00469.jpg-->
-    
+
 
 
 
@@ -42081,7 +42088,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -42091,7 +42098,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -42148,7 +42155,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -42158,7 +42165,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -42215,7 +42222,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -42225,7 +42232,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -42282,7 +42289,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -42292,7 +42299,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -42349,7 +42356,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -42359,7 +42366,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -42416,7 +42423,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -42426,7 +42433,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -42483,7 +42490,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -42493,7 +42500,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -42550,7 +42557,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -42560,7 +42567,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -42617,7 +42624,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -42627,7 +42634,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -42684,7 +42691,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -42694,7 +42701,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -42736,9 +42743,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00470--mixed4c-00479.jpg-->
-    
+
 
 
 
@@ -43223,7 +43230,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -43233,7 +43240,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -43290,7 +43297,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -43300,7 +43307,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -43357,7 +43364,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -43367,7 +43374,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -43424,7 +43431,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -43434,7 +43441,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -43491,7 +43498,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -43501,7 +43508,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -43558,7 +43565,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -43568,7 +43575,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -43625,7 +43632,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -43635,7 +43642,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -43692,7 +43699,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -43702,7 +43709,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -43759,7 +43766,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -43769,7 +43776,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -43826,7 +43833,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -43836,7 +43843,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -43878,9 +43885,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00480--mixed4c-00489.jpg-->
-    
+
 
 
 
@@ -44375,7 +44382,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -44385,7 +44392,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -44442,7 +44449,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -44452,7 +44459,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -44509,7 +44516,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -44519,7 +44526,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -44576,7 +44583,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -44586,7 +44593,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -44643,7 +44650,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -44653,7 +44660,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -44710,7 +44717,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -44720,7 +44727,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -44777,7 +44784,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -44787,7 +44794,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -44844,7 +44851,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -44854,7 +44861,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -44911,7 +44918,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -44921,7 +44928,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -44978,7 +44985,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -44988,7 +44995,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -45030,9 +45037,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00490--mixed4c-00499.jpg-->
-    
+
 
 
 
@@ -45537,7 +45544,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -45547,7 +45554,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -45604,7 +45611,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -45614,7 +45621,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -45671,7 +45678,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -45681,7 +45688,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -45738,7 +45745,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -45748,7 +45755,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -45805,7 +45812,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -45815,7 +45822,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -45872,7 +45879,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -45882,7 +45889,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -45939,7 +45946,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -45949,7 +45956,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -46006,7 +46013,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -46016,7 +46023,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -46073,7 +46080,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -46083,7 +46090,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -46140,7 +46147,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -46150,7 +46157,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -46192,9 +46199,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00500--mixed4c-00509.jpg-->
-    
+
 
 
 
@@ -46709,7 +46716,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -46719,7 +46726,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -46776,7 +46783,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -46786,7 +46793,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -46843,7 +46850,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -46853,7 +46860,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -46910,7 +46917,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -46920,7 +46927,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -46977,7 +46984,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -46987,7 +46994,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -47044,7 +47051,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -47054,7 +47061,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -47111,7 +47118,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -47121,7 +47128,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -47178,7 +47185,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -47188,7 +47195,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -47245,7 +47252,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -47255,7 +47262,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -47312,7 +47319,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -47322,7 +47329,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -47364,9 +47371,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4c-00510--mixed4c-00511.jpg-->
-    
+
 
 
 
@@ -47891,7 +47898,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -47901,7 +47908,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -47958,7 +47965,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -47968,7 +47975,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -48010,9 +48017,8 @@
       </div>
       </d-figure>
       </li>
-  
+
   </ul>
   </d-article>
   <distill-footer></distill-footer>
 </body>
-  

--- a/public/appendix/googlenet/4d.html
+++ b/public/appendix/googlenet/4d.html
@@ -5,21 +5,21 @@
   <meta charset="utf8">
   <script src="https://distill.pub/template.v2.js"></script>
   <style>
-  
+
     d-article {
       line-height: 1em;
     }
-    
+
     d-byline,
     d-appendix {
       display: none;
     }
-  
+
     h4 {
       display: block;
       width: 100%;
     }
-    
+
     d-figure {
       display: flex;
       flex-flow: row;
@@ -31,7 +31,7 @@
       margin-bottom: 1em;
       justify-content: center;
     }
-    
+
     .positive,
     .negative {
       display: flex;
@@ -40,7 +40,7 @@
       align-content: flex-start;
       max-width: 370px;
     }
-    
+
     .positive {
       padding-left: 1em;
       padding-right: 1em;
@@ -50,14 +50,14 @@
       border-right: 1px solid rgba(0,0,0,0.1);
       justify-content: space-between;
     }
-    
+
     .figcaption {
       display: block;
       color: rgba(0, 0, 0, 0.6);
       font-size: 12px;
       line-height: 1.5em;
     }
-    
+
     .diversity {
       display: flex;
       flex-flow: row;
@@ -65,61 +65,61 @@
       width: 148px;
       height: 147px
     }
-    
+
     .diversity > div {
       zoom: 0.496598639;
     }
-    
+
     .channel {
       margin-right: 1em;
     }
-    
+
     .channels {
       grid-column: screen;
       list-style: none;
       padding-left: 0;
     }
-    
+
     .channels li {
       contain: content;
       overflow: hidden;
     }
-    
+
     .sprite {
       display: inline-block;
       margin: 1px;
       width: 147px;
       height: 147px;
     }
-    
+
     .sprite.neuron {
       background-position-x: 0px;
     }
-    
+
     .sprite.channel {
       background-position-x: -147px;
     }
-    
+
     .sprite.channel-negative {
       background-position-x: -294px;
     }
-    
+
     .sprite.channel-diversity-0 {
       background-position-x: -441px;
     }
-    
+
     .sprite.channel-diversity-1 {
       background-position-x: -588px;
     }
-    
+
     .sprite.channel-diversity-2 {
       background-position-x: -735px;
     }
-    
+
     .sprite.channel-diversity-3 {
       background-position-x: -882px;
     }
-    
+
     .dataset-examples {
       display: flex;
       flex-flow: row;
@@ -127,7 +127,7 @@
       width: 375px;
       height: 147px
     }
-    
+
     .dataset-examples .sprite {
       height: 73px;
       width: 73px;
@@ -136,16 +136,16 @@
       margin-bottom: 0;
       margin-right: 0;
     }
-    
-    
+
+
       .channels .sprite.dataset-index-0 {
         background-position-x: -1029px !important;
       }
-      
+
       .channels .sprite.index-0 {
         background-position-y: -0px;
       }
-      
+
       .channels .dataset-negative .sprite.index-0 {
         background-position-y: -74px !important;
       }
@@ -153,11 +153,11 @@
       .channels .sprite.dataset-index-1 {
         background-position-x: -1103px !important;
       }
-      
+
       .channels .sprite.index-1 {
         background-position-y: -147px;
       }
-      
+
       .channels .dataset-negative .sprite.index-1 {
         background-position-y: -221px !important;
       }
@@ -165,11 +165,11 @@
       .channels .sprite.dataset-index-2 {
         background-position-x: -1177px !important;
       }
-      
+
       .channels .sprite.index-2 {
         background-position-y: -294px;
       }
-      
+
       .channels .dataset-negative .sprite.index-2 {
         background-position-y: -368px !important;
       }
@@ -177,11 +177,11 @@
       .channels .sprite.dataset-index-3 {
         background-position-x: -1251px !important;
       }
-      
+
       .channels .sprite.index-3 {
         background-position-y: -441px;
       }
-      
+
       .channels .dataset-negative .sprite.index-3 {
         background-position-y: -515px !important;
       }
@@ -189,11 +189,11 @@
       .channels .sprite.dataset-index-4 {
         background-position-x: -1325px !important;
       }
-      
+
       .channels .sprite.index-4 {
         background-position-y: -588px;
       }
-      
+
       .channels .dataset-negative .sprite.index-4 {
         background-position-y: -662px !important;
       }
@@ -201,11 +201,11 @@
       .channels .sprite.dataset-index-5 {
         background-position-x: -1399px !important;
       }
-      
+
       .channels .sprite.index-5 {
         background-position-y: -735px;
       }
-      
+
       .channels .dataset-negative .sprite.index-5 {
         background-position-y: -809px !important;
       }
@@ -213,11 +213,11 @@
       .channels .sprite.dataset-index-6 {
         background-position-x: -1473px !important;
       }
-      
+
       .channels .sprite.index-6 {
         background-position-y: -882px;
       }
-      
+
       .channels .dataset-negative .sprite.index-6 {
         background-position-y: -956px !important;
       }
@@ -225,11 +225,11 @@
       .channels .sprite.dataset-index-7 {
         background-position-x: -1547px !important;
       }
-      
+
       .channels .sprite.index-7 {
         background-position-y: -1029px;
       }
-      
+
       .channels .dataset-negative .sprite.index-7 {
         background-position-y: -1103px !important;
       }
@@ -237,11 +237,11 @@
       .channels .sprite.dataset-index-8 {
         background-position-x: -1621px !important;
       }
-      
+
       .channels .sprite.index-8 {
         background-position-y: -1176px;
       }
-      
+
       .channels .dataset-negative .sprite.index-8 {
         background-position-y: -1250px !important;
       }
@@ -249,20 +249,20 @@
       .channels .sprite.dataset-index-9 {
         background-position-x: -1695px !important;
       }
-      
+
       .channels .sprite.index-9 {
         background-position-y: -1323px;
       }
-      
+
       .channels .dataset-negative .sprite.index-9 {
         background-position-y: -1397px !important;
       }
-    
-    
+
+
     .article-nav {
       grid-column: page;
     }
-    
+
     .navlist li {
       display: inline;
       list-style-type: none;
@@ -300,10 +300,10 @@
     <h1>Layer 4d</h1>
   </d-title>
   <d-article>
-  
+
   <nav class="article-nav">
-  
-    
+
+
     <ul class="navlist">
       <li><a href="https://distill.pub/2017/feature-visualization/appendix/">Appendix overview</a></li>
       <li><a href="https://distill.pub/2017/feature-visualization/">Main article</a></li>
@@ -325,7 +325,7 @@
         <a href="4c.html">Layer 4c</a>
       </li>
       <li>
-        <a href="4d.html">Layer 4d</a>
+        <a href="4d.html"><b>Layer 4d</b></a>
       </li>
       <li>
         <a href="4e.html">Layer 4e</a>
@@ -337,14 +337,21 @@
         <a href="5b.html">Layer 5b</a>
       </li>
     </ul>
-  
+
+    <ul class="navlist">
+      <li> <a href="4d.html#4d-0">4d 1x1</a> <span style="color: #777;">(0:112)</span> </li>
+      <li> <a href="4d.html#4d-112">4d 3x3</a> <span style="color: #777;">(112:400)</span> </li>
+      <li> <a href="4d.html#4d-400">4d 5x5</a> <span style="color: #777;">(400:464)</span> </li>
+      <li> <a href="4d.html#4d-464">4d pool</a> <span style="color: #777;">(464:528)</span> </li>
+    </ul>
+
   </nav>
-  
+
   <hr style="margin-top: 20px;"/>
-  
+
   <ul class="channels">
     <!--mixed4d-00000--mixed4d-00009.jpg-->
-    
+
       <li id="channel-0">
       <d-figure id="4d-0">
       <style data-img-src="images/mixed4d-00000--mixed4d-00009.jpg" data-channel="0"></style>
@@ -359,7 +366,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -369,7 +376,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -426,7 +433,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -436,7 +443,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -493,7 +500,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -503,7 +510,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -560,7 +567,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -570,7 +577,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -627,7 +634,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -637,7 +644,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -694,7 +701,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -704,7 +711,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -761,7 +768,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -771,7 +778,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -828,7 +835,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -838,7 +845,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -895,7 +902,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -905,7 +912,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -962,7 +969,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -972,7 +979,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -1014,9 +1021,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00010--mixed4d-00019.jpg-->
-    
+
 
 
 
@@ -1041,7 +1048,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -1051,7 +1058,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -1108,7 +1115,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -1118,7 +1125,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -1175,7 +1182,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -1185,7 +1192,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -1242,7 +1249,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -1252,7 +1259,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -1309,7 +1316,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -1319,7 +1326,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -1376,7 +1383,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -1386,7 +1393,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -1443,7 +1450,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -1453,7 +1460,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -1510,7 +1517,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -1520,7 +1527,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -1577,7 +1584,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -1587,7 +1594,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -1644,7 +1651,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -1654,7 +1661,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -1696,9 +1703,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00020--mixed4d-00029.jpg-->
-    
+
 
 
 
@@ -1733,7 +1740,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -1743,7 +1750,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -1800,7 +1807,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -1810,7 +1817,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -1867,7 +1874,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -1877,7 +1884,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -1934,7 +1941,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -1944,7 +1951,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -2001,7 +2008,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -2011,7 +2018,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -2068,7 +2075,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -2078,7 +2085,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -2135,7 +2142,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -2145,7 +2152,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -2202,7 +2209,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -2212,7 +2219,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -2269,7 +2276,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -2279,7 +2286,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -2336,7 +2343,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -2346,7 +2353,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -2388,9 +2395,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00030--mixed4d-00039.jpg-->
-    
+
 
 
 
@@ -2435,7 +2442,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -2445,7 +2452,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -2502,7 +2509,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -2512,7 +2519,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -2569,7 +2576,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -2579,7 +2586,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -2636,7 +2643,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -2646,7 +2653,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -2703,7 +2710,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -2713,7 +2720,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -2770,7 +2777,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -2780,7 +2787,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -2837,7 +2844,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -2847,7 +2854,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -2904,7 +2911,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -2914,7 +2921,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -2971,7 +2978,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -2981,7 +2988,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -3038,7 +3045,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -3048,7 +3055,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -3090,9 +3097,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00040--mixed4d-00049.jpg-->
-    
+
 
 
 
@@ -3147,7 +3154,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -3157,7 +3164,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -3214,7 +3221,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -3224,7 +3231,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -3281,7 +3288,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -3291,7 +3298,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -3348,7 +3355,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -3358,7 +3365,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -3415,7 +3422,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -3425,7 +3432,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -3482,7 +3489,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -3492,7 +3499,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -3549,7 +3556,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -3559,7 +3566,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -3616,7 +3623,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -3626,7 +3633,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -3683,7 +3690,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -3693,7 +3700,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -3750,7 +3757,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -3760,7 +3767,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -3802,9 +3809,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00050--mixed4d-00059.jpg-->
-    
+
 
 
 
@@ -3869,7 +3876,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -3879,7 +3886,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -3936,7 +3943,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -3946,7 +3953,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -4003,7 +4010,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -4013,7 +4020,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -4070,7 +4077,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -4080,7 +4087,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -4137,7 +4144,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -4147,7 +4154,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -4204,7 +4211,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -4214,7 +4221,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -4271,7 +4278,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -4281,7 +4288,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -4338,7 +4345,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -4348,7 +4355,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -4405,7 +4412,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -4415,7 +4422,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -4472,7 +4479,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -4482,7 +4489,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -4524,9 +4531,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00060--mixed4d-00069.jpg-->
-    
+
 
 
 
@@ -4601,7 +4608,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -4611,7 +4618,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -4668,7 +4675,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -4678,7 +4685,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -4735,7 +4742,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -4745,7 +4752,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -4802,7 +4809,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -4812,7 +4819,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -4869,7 +4876,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -4879,7 +4886,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -4936,7 +4943,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -4946,7 +4953,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -5003,7 +5010,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -5013,7 +5020,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -5070,7 +5077,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -5080,7 +5087,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -5137,7 +5144,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -5147,7 +5154,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -5204,7 +5211,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -5214,7 +5221,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -5256,9 +5263,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00070--mixed4d-00079.jpg-->
-    
+
 
 
 
@@ -5343,7 +5350,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -5353,7 +5360,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -5410,7 +5417,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -5420,7 +5427,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -5477,7 +5484,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -5487,7 +5494,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -5544,7 +5551,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -5554,7 +5561,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -5611,7 +5618,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -5621,7 +5628,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -5678,7 +5685,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -5688,7 +5695,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -5745,7 +5752,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -5755,7 +5762,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -5812,7 +5819,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -5822,7 +5829,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -5879,7 +5886,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -5889,7 +5896,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -5946,7 +5953,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -5956,7 +5963,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -5998,9 +6005,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00080--mixed4d-00089.jpg-->
-    
+
 
 
 
@@ -6095,7 +6102,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -6105,7 +6112,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -6162,7 +6169,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -6172,7 +6179,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -6229,7 +6236,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -6239,7 +6246,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -6296,7 +6303,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -6306,7 +6313,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -6363,7 +6370,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -6373,7 +6380,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -6430,7 +6437,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -6440,7 +6447,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -6497,7 +6504,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -6507,7 +6514,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -6564,7 +6571,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -6574,7 +6581,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -6631,7 +6638,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -6641,7 +6648,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -6698,7 +6705,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -6708,7 +6715,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -6750,9 +6757,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00090--mixed4d-00099.jpg-->
-    
+
 
 
 
@@ -6857,7 +6864,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -6867,7 +6874,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -6924,7 +6931,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -6934,7 +6941,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -6991,7 +6998,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -7001,7 +7008,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -7058,7 +7065,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -7068,7 +7075,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -7125,7 +7132,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -7135,7 +7142,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -7192,7 +7199,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -7202,7 +7209,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -7259,7 +7266,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -7269,7 +7276,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -7326,7 +7333,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -7336,7 +7343,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -7393,7 +7400,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -7403,7 +7410,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -7460,7 +7467,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -7470,7 +7477,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -7512,9 +7519,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00100--mixed4d-00109.jpg-->
-    
+
 
 
 
@@ -7629,7 +7636,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -7639,7 +7646,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -7696,7 +7703,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -7706,7 +7713,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -7763,7 +7770,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -7773,7 +7780,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -7830,7 +7837,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -7840,7 +7847,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -7897,7 +7904,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -7907,7 +7914,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -7964,7 +7971,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -7974,7 +7981,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -8031,7 +8038,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -8041,7 +8048,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -8098,7 +8105,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -8108,7 +8115,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -8165,7 +8172,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -8175,7 +8182,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -8232,7 +8239,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -8242,7 +8249,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -8284,9 +8291,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00110--mixed4d-00119.jpg-->
-    
+
 
 
 
@@ -8411,7 +8418,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -8421,7 +8428,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -8478,7 +8485,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -8488,7 +8495,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -8545,7 +8552,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -8555,7 +8562,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -8612,7 +8619,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -8622,7 +8629,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -8679,7 +8686,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -8689,7 +8696,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -8746,7 +8753,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -8756,7 +8763,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -8813,7 +8820,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -8823,7 +8830,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -8880,7 +8887,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -8890,7 +8897,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -8947,7 +8954,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -8957,7 +8964,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -9014,7 +9021,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -9024,7 +9031,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -9066,9 +9073,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00120--mixed4d-00129.jpg-->
-    
+
 
 
 
@@ -9203,7 +9210,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -9213,7 +9220,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -9270,7 +9277,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -9280,7 +9287,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -9337,7 +9344,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -9347,7 +9354,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -9404,7 +9411,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -9414,7 +9421,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -9471,7 +9478,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -9481,7 +9488,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -9538,7 +9545,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -9548,7 +9555,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -9605,7 +9612,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -9615,7 +9622,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -9672,7 +9679,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -9682,7 +9689,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -9739,7 +9746,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -9749,7 +9756,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -9806,7 +9813,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -9816,7 +9823,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -9858,9 +9865,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00130--mixed4d-00139.jpg-->
-    
+
 
 
 
@@ -10005,7 +10012,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -10015,7 +10022,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -10072,7 +10079,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -10082,7 +10089,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -10139,7 +10146,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -10149,7 +10156,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -10206,7 +10213,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -10216,7 +10223,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -10273,7 +10280,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -10283,7 +10290,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -10340,7 +10347,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -10350,7 +10357,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -10407,7 +10414,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -10417,7 +10424,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -10474,7 +10481,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -10484,7 +10491,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -10541,7 +10548,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -10551,7 +10558,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -10608,7 +10615,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -10618,7 +10625,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -10660,9 +10667,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00140--mixed4d-00149.jpg-->
-    
+
 
 
 
@@ -10817,7 +10824,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -10827,7 +10834,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -10884,7 +10891,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -10894,7 +10901,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -10951,7 +10958,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -10961,7 +10968,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -11018,7 +11025,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -11028,7 +11035,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -11085,7 +11092,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -11095,7 +11102,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -11152,7 +11159,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -11162,7 +11169,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -11219,7 +11226,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -11229,7 +11236,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -11286,7 +11293,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -11296,7 +11303,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -11353,7 +11360,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -11363,7 +11370,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -11420,7 +11427,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -11430,7 +11437,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -11472,9 +11479,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00150--mixed4d-00159.jpg-->
-    
+
 
 
 
@@ -11639,7 +11646,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -11649,7 +11656,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -11706,7 +11713,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -11716,7 +11723,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -11773,7 +11780,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -11783,7 +11790,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -11840,7 +11847,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -11850,7 +11857,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -11907,7 +11914,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -11917,7 +11924,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -11974,7 +11981,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -11984,7 +11991,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -12041,7 +12048,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -12051,7 +12058,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -12108,7 +12115,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -12118,7 +12125,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -12175,7 +12182,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -12185,7 +12192,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -12242,7 +12249,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -12252,7 +12259,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -12294,9 +12301,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00160--mixed4d-00169.jpg-->
-    
+
 
 
 
@@ -12471,7 +12478,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -12481,7 +12488,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -12538,7 +12545,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -12548,7 +12555,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -12605,7 +12612,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -12615,7 +12622,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -12672,7 +12679,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -12682,7 +12689,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -12739,7 +12746,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -12749,7 +12756,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -12806,7 +12813,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -12816,7 +12823,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -12873,7 +12880,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -12883,7 +12890,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -12940,7 +12947,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -12950,7 +12957,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -13007,7 +13014,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -13017,7 +13024,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -13074,7 +13081,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -13084,7 +13091,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -13126,9 +13133,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00170--mixed4d-00179.jpg-->
-    
+
 
 
 
@@ -13313,7 +13320,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -13323,7 +13330,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -13380,7 +13387,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -13390,7 +13397,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -13447,7 +13454,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -13457,7 +13464,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -13514,7 +13521,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -13524,7 +13531,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -13581,7 +13588,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -13591,7 +13598,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -13648,7 +13655,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -13658,7 +13665,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -13715,7 +13722,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -13725,7 +13732,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -13782,7 +13789,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -13792,7 +13799,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -13849,7 +13856,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -13859,7 +13866,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -13916,7 +13923,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -13926,7 +13933,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -13968,9 +13975,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00180--mixed4d-00189.jpg-->
-    
+
 
 
 
@@ -14165,7 +14172,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -14175,7 +14182,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -14232,7 +14239,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -14242,7 +14249,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -14299,7 +14306,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -14309,7 +14316,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -14366,7 +14373,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -14376,7 +14383,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -14433,7 +14440,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -14443,7 +14450,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -14500,7 +14507,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -14510,7 +14517,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -14567,7 +14574,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -14577,7 +14584,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -14634,7 +14641,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -14644,7 +14651,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -14701,7 +14708,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -14711,7 +14718,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -14768,7 +14775,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -14778,7 +14785,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -14820,9 +14827,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00190--mixed4d-00199.jpg-->
-    
+
 
 
 
@@ -15027,7 +15034,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -15037,7 +15044,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -15094,7 +15101,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -15104,7 +15111,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -15161,7 +15168,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -15171,7 +15178,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -15228,7 +15235,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -15238,7 +15245,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -15295,7 +15302,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -15305,7 +15312,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -15362,7 +15369,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -15372,7 +15379,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -15429,7 +15436,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -15439,7 +15446,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -15496,7 +15503,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -15506,7 +15513,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -15563,7 +15570,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -15573,7 +15580,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -15630,7 +15637,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -15640,7 +15647,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -15682,9 +15689,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00200--mixed4d-00209.jpg-->
-    
+
 
 
 
@@ -15899,7 +15906,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -15909,7 +15916,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -15966,7 +15973,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -15976,7 +15983,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -16033,7 +16040,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -16043,7 +16050,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -16100,7 +16107,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -16110,7 +16117,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -16167,7 +16174,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -16177,7 +16184,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -16234,7 +16241,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -16244,7 +16251,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -16301,7 +16308,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -16311,7 +16318,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -16368,7 +16375,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -16378,7 +16385,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -16435,7 +16442,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -16445,7 +16452,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -16502,7 +16509,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -16512,7 +16519,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -16554,9 +16561,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00210--mixed4d-00219.jpg-->
-    
+
 
 
 
@@ -16781,7 +16788,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -16791,7 +16798,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -16848,7 +16855,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -16858,7 +16865,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -16915,7 +16922,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -16925,7 +16932,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -16982,7 +16989,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -16992,7 +16999,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -17049,7 +17056,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -17059,7 +17066,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -17116,7 +17123,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -17126,7 +17133,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -17183,7 +17190,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -17193,7 +17200,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -17250,7 +17257,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -17260,7 +17267,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -17317,7 +17324,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -17327,7 +17334,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -17384,7 +17391,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -17394,7 +17401,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -17436,9 +17443,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00220--mixed4d-00229.jpg-->
-    
+
 
 
 
@@ -17673,7 +17680,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -17683,7 +17690,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -17740,7 +17747,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -17750,7 +17757,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -17807,7 +17814,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -17817,7 +17824,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -17874,7 +17881,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -17884,7 +17891,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -17941,7 +17948,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -17951,7 +17958,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -18008,7 +18015,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -18018,7 +18025,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -18075,7 +18082,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -18085,7 +18092,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -18142,7 +18149,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -18152,7 +18159,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -18209,7 +18216,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -18219,7 +18226,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -18276,7 +18283,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -18286,7 +18293,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -18328,9 +18335,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00230--mixed4d-00239.jpg-->
-    
+
 
 
 
@@ -18575,7 +18582,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -18585,7 +18592,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -18642,7 +18649,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -18652,7 +18659,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -18709,7 +18716,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -18719,7 +18726,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -18776,7 +18783,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -18786,7 +18793,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -18843,7 +18850,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -18853,7 +18860,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -18910,7 +18917,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -18920,7 +18927,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -18977,7 +18984,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -18987,7 +18994,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -19044,7 +19051,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -19054,7 +19061,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -19111,7 +19118,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -19121,7 +19128,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -19178,7 +19185,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -19188,7 +19195,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -19230,9 +19237,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00240--mixed4d-00249.jpg-->
-    
+
 
 
 
@@ -19487,7 +19494,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -19497,7 +19504,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -19554,7 +19561,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -19564,7 +19571,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -19621,7 +19628,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -19631,7 +19638,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -19688,7 +19695,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -19698,7 +19705,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -19755,7 +19762,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -19765,7 +19772,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -19822,7 +19829,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -19832,7 +19839,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -19889,7 +19896,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -19899,7 +19906,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -19956,7 +19963,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -19966,7 +19973,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -20023,7 +20030,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -20033,7 +20040,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -20090,7 +20097,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -20100,7 +20107,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -20142,9 +20149,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00250--mixed4d-00259.jpg-->
-    
+
 
 
 
@@ -20409,7 +20416,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -20419,7 +20426,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -20476,7 +20483,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -20486,7 +20493,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -20543,7 +20550,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -20553,7 +20560,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -20610,7 +20617,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -20620,7 +20627,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -20677,7 +20684,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -20687,7 +20694,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -20744,7 +20751,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -20754,7 +20761,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -20811,7 +20818,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -20821,7 +20828,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -20878,7 +20885,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -20888,7 +20895,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -20945,7 +20952,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -20955,7 +20962,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -21012,7 +21019,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -21022,7 +21029,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -21064,9 +21071,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00260--mixed4d-00269.jpg-->
-    
+
 
 
 
@@ -21341,7 +21348,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -21351,7 +21358,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -21408,7 +21415,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -21418,7 +21425,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -21475,7 +21482,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -21485,7 +21492,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -21542,7 +21549,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -21552,7 +21559,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -21609,7 +21616,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -21619,7 +21626,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -21676,7 +21683,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -21686,7 +21693,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -21743,7 +21750,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -21753,7 +21760,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -21810,7 +21817,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -21820,7 +21827,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -21877,7 +21884,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -21887,7 +21894,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -21944,7 +21951,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -21954,7 +21961,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -21996,9 +22003,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00270--mixed4d-00279.jpg-->
-    
+
 
 
 
@@ -22283,7 +22290,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -22293,7 +22300,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -22350,7 +22357,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -22360,7 +22367,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -22417,7 +22424,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -22427,7 +22434,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -22484,7 +22491,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -22494,7 +22501,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -22551,7 +22558,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -22561,7 +22568,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -22618,7 +22625,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -22628,7 +22635,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -22685,7 +22692,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -22695,7 +22702,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -22752,7 +22759,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -22762,7 +22769,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -22819,7 +22826,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -22829,7 +22836,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -22886,7 +22893,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -22896,7 +22903,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -22938,9 +22945,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00280--mixed4d-00289.jpg-->
-    
+
 
 
 
@@ -23235,7 +23242,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -23245,7 +23252,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -23302,7 +23309,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -23312,7 +23319,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -23369,7 +23376,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -23379,7 +23386,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -23436,7 +23443,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -23446,7 +23453,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -23503,7 +23510,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -23513,7 +23520,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -23570,7 +23577,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -23580,7 +23587,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -23637,7 +23644,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -23647,7 +23654,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -23704,7 +23711,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -23714,7 +23721,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -23771,7 +23778,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -23781,7 +23788,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -23838,7 +23845,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -23848,7 +23855,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -23890,9 +23897,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00290--mixed4d-00299.jpg-->
-    
+
 
 
 
@@ -24197,7 +24204,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -24207,7 +24214,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -24264,7 +24271,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -24274,7 +24281,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -24331,7 +24338,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -24341,7 +24348,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -24398,7 +24405,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -24408,7 +24415,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -24465,7 +24472,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -24475,7 +24482,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -24532,7 +24539,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -24542,7 +24549,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -24599,7 +24606,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -24609,7 +24616,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -24666,7 +24673,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -24676,7 +24683,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -24733,7 +24740,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -24743,7 +24750,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -24800,7 +24807,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -24810,7 +24817,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -24852,9 +24859,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00300--mixed4d-00309.jpg-->
-    
+
 
 
 
@@ -25169,7 +25176,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -25179,7 +25186,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -25236,7 +25243,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -25246,7 +25253,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -25303,7 +25310,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -25313,7 +25320,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -25370,7 +25377,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -25380,7 +25387,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -25437,7 +25444,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -25447,7 +25454,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -25504,7 +25511,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -25514,7 +25521,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -25571,7 +25578,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -25581,7 +25588,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -25638,7 +25645,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -25648,7 +25655,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -25705,7 +25712,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -25715,7 +25722,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -25772,7 +25779,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -25782,7 +25789,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -25824,9 +25831,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00310--mixed4d-00319.jpg-->
-    
+
 
 
 
@@ -26151,7 +26158,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -26161,7 +26168,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -26218,7 +26225,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -26228,7 +26235,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -26285,7 +26292,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -26295,7 +26302,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -26352,7 +26359,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -26362,7 +26369,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -26419,7 +26426,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -26429,7 +26436,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -26486,7 +26493,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -26496,7 +26503,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -26553,7 +26560,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -26563,7 +26570,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -26620,7 +26627,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -26630,7 +26637,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -26687,7 +26694,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -26697,7 +26704,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -26754,7 +26761,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -26764,7 +26771,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -26806,9 +26813,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00320--mixed4d-00329.jpg-->
-    
+
 
 
 
@@ -27143,7 +27150,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -27153,7 +27160,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -27210,7 +27217,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -27220,7 +27227,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -27277,7 +27284,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -27287,7 +27294,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -27344,7 +27351,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -27354,7 +27361,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -27411,7 +27418,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -27421,7 +27428,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -27478,7 +27485,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -27488,7 +27495,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -27545,7 +27552,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -27555,7 +27562,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -27612,7 +27619,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -27622,7 +27629,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -27679,7 +27686,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -27689,7 +27696,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -27746,7 +27753,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -27756,7 +27763,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -27798,9 +27805,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00330--mixed4d-00339.jpg-->
-    
+
 
 
 
@@ -28145,7 +28152,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -28155,7 +28162,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -28212,7 +28219,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -28222,7 +28229,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -28279,7 +28286,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -28289,7 +28296,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -28346,7 +28353,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -28356,7 +28363,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -28413,7 +28420,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -28423,7 +28430,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -28480,7 +28487,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -28490,7 +28497,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -28547,7 +28554,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -28557,7 +28564,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -28614,7 +28621,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -28624,7 +28631,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -28681,7 +28688,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -28691,7 +28698,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -28748,7 +28755,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -28758,7 +28765,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -28800,9 +28807,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00340--mixed4d-00349.jpg-->
-    
+
 
 
 
@@ -29157,7 +29164,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -29167,7 +29174,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -29224,7 +29231,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -29234,7 +29241,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -29291,7 +29298,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -29301,7 +29308,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -29358,7 +29365,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -29368,7 +29375,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -29425,7 +29432,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -29435,7 +29442,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -29492,7 +29499,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -29502,7 +29509,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -29559,7 +29566,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -29569,7 +29576,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -29626,7 +29633,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -29636,7 +29643,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -29693,7 +29700,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -29703,7 +29710,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -29760,7 +29767,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -29770,7 +29777,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -29812,9 +29819,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00350--mixed4d-00359.jpg-->
-    
+
 
 
 
@@ -30179,7 +30186,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -30189,7 +30196,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -30246,7 +30253,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -30256,7 +30263,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -30313,7 +30320,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -30323,7 +30330,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -30380,7 +30387,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -30390,7 +30397,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -30447,7 +30454,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -30457,7 +30464,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -30514,7 +30521,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -30524,7 +30531,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -30581,7 +30588,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -30591,7 +30598,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -30648,7 +30655,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -30658,7 +30665,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -30715,7 +30722,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -30725,7 +30732,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -30782,7 +30789,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -30792,7 +30799,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -30834,9 +30841,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00360--mixed4d-00369.jpg-->
-    
+
 
 
 
@@ -31211,7 +31218,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -31221,7 +31228,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -31278,7 +31285,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -31288,7 +31295,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -31345,7 +31352,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -31355,7 +31362,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -31412,7 +31419,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -31422,7 +31429,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -31479,7 +31486,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -31489,7 +31496,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -31546,7 +31553,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -31556,7 +31563,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -31613,7 +31620,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -31623,7 +31630,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -31680,7 +31687,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -31690,7 +31697,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -31747,7 +31754,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -31757,7 +31764,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -31814,7 +31821,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -31824,7 +31831,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -31866,9 +31873,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00370--mixed4d-00379.jpg-->
-    
+
 
 
 
@@ -32253,7 +32260,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -32263,7 +32270,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -32320,7 +32327,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -32330,7 +32337,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -32387,7 +32394,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -32397,7 +32404,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -32454,7 +32461,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -32464,7 +32471,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -32521,7 +32528,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -32531,7 +32538,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -32588,7 +32595,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -32598,7 +32605,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -32655,7 +32662,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -32665,7 +32672,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -32722,7 +32729,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -32732,7 +32739,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -32789,7 +32796,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -32799,7 +32806,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -32856,7 +32863,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -32866,7 +32873,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -32908,9 +32915,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00380--mixed4d-00389.jpg-->
-    
+
 
 
 
@@ -33305,7 +33312,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -33315,7 +33322,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -33372,7 +33379,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -33382,7 +33389,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -33439,7 +33446,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -33449,7 +33456,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -33506,7 +33513,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -33516,7 +33523,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -33573,7 +33580,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -33583,7 +33590,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -33640,7 +33647,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -33650,7 +33657,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -33707,7 +33714,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -33717,7 +33724,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -33774,7 +33781,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -33784,7 +33791,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -33841,7 +33848,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -33851,7 +33858,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -33908,7 +33915,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -33918,7 +33925,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -33960,9 +33967,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00390--mixed4d-00399.jpg-->
-    
+
 
 
 
@@ -34367,7 +34374,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -34377,7 +34384,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -34434,7 +34441,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -34444,7 +34451,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -34501,7 +34508,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -34511,7 +34518,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -34568,7 +34575,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -34578,7 +34585,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -34635,7 +34642,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -34645,7 +34652,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -34702,7 +34709,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -34712,7 +34719,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -34769,7 +34776,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -34779,7 +34786,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -34836,7 +34843,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -34846,7 +34853,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -34903,7 +34910,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -34913,7 +34920,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -34970,7 +34977,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -34980,7 +34987,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -35022,9 +35029,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00400--mixed4d-00409.jpg-->
-    
+
 
 
 
@@ -35439,7 +35446,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -35449,7 +35456,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -35506,7 +35513,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -35516,7 +35523,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -35573,7 +35580,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -35583,7 +35590,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -35640,7 +35647,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -35650,7 +35657,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -35707,7 +35714,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -35717,7 +35724,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -35774,7 +35781,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -35784,7 +35791,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -35841,7 +35848,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -35851,7 +35858,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -35908,7 +35915,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -35918,7 +35925,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -35975,7 +35982,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -35985,7 +35992,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -36042,7 +36049,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -36052,7 +36059,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -36094,9 +36101,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00410--mixed4d-00419.jpg-->
-    
+
 
 
 
@@ -36521,7 +36528,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -36531,7 +36538,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -36588,7 +36595,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -36598,7 +36605,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -36655,7 +36662,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -36665,7 +36672,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -36722,7 +36729,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -36732,7 +36739,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -36789,7 +36796,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -36799,7 +36806,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -36856,7 +36863,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -36866,7 +36873,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -36923,7 +36930,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -36933,7 +36940,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -36990,7 +36997,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -37000,7 +37007,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -37057,7 +37064,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -37067,7 +37074,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -37124,7 +37131,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -37134,7 +37141,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -37176,9 +37183,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00420--mixed4d-00429.jpg-->
-    
+
 
 
 
@@ -37613,7 +37620,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -37623,7 +37630,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -37680,7 +37687,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -37690,7 +37697,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -37747,7 +37754,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -37757,7 +37764,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -37814,7 +37821,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -37824,7 +37831,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -37881,7 +37888,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -37891,7 +37898,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -37948,7 +37955,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -37958,7 +37965,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -38015,7 +38022,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -38025,7 +38032,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -38082,7 +38089,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -38092,7 +38099,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -38149,7 +38156,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -38159,7 +38166,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -38216,7 +38223,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -38226,7 +38233,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -38268,9 +38275,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00430--mixed4d-00439.jpg-->
-    
+
 
 
 
@@ -38715,7 +38722,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -38725,7 +38732,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -38782,7 +38789,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -38792,7 +38799,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -38849,7 +38856,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -38859,7 +38866,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -38916,7 +38923,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -38926,7 +38933,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -38983,7 +38990,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -38993,7 +39000,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -39050,7 +39057,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -39060,7 +39067,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -39117,7 +39124,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -39127,7 +39134,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -39184,7 +39191,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -39194,7 +39201,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -39251,7 +39258,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -39261,7 +39268,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -39318,7 +39325,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -39328,7 +39335,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -39370,9 +39377,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00440--mixed4d-00449.jpg-->
-    
+
 
 
 
@@ -39827,7 +39834,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -39837,7 +39844,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -39894,7 +39901,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -39904,7 +39911,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -39961,7 +39968,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -39971,7 +39978,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -40028,7 +40035,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -40038,7 +40045,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -40095,7 +40102,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -40105,7 +40112,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -40162,7 +40169,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -40172,7 +40179,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -40229,7 +40236,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -40239,7 +40246,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -40296,7 +40303,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -40306,7 +40313,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -40363,7 +40370,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -40373,7 +40380,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -40430,7 +40437,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -40440,7 +40447,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -40482,9 +40489,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00450--mixed4d-00459.jpg-->
-    
+
 
 
 
@@ -40949,7 +40956,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -40959,7 +40966,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -41016,7 +41023,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -41026,7 +41033,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -41083,7 +41090,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -41093,7 +41100,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -41150,7 +41157,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -41160,7 +41167,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -41217,7 +41224,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -41227,7 +41234,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -41284,7 +41291,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -41294,7 +41301,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -41351,7 +41358,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -41361,7 +41368,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -41418,7 +41425,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -41428,7 +41435,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -41485,7 +41492,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -41495,7 +41502,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -41552,7 +41559,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -41562,7 +41569,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -41604,9 +41611,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00460--mixed4d-00469.jpg-->
-    
+
 
 
 
@@ -42081,7 +42088,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -42091,7 +42098,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -42148,7 +42155,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -42158,7 +42165,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -42215,7 +42222,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -42225,7 +42232,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -42282,7 +42289,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -42292,7 +42299,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -42349,7 +42356,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -42359,7 +42366,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -42416,7 +42423,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -42426,7 +42433,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -42483,7 +42490,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -42493,7 +42500,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -42550,7 +42557,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -42560,7 +42567,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -42617,7 +42624,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -42627,7 +42634,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -42684,7 +42691,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -42694,7 +42701,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -42736,9 +42743,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00470--mixed4d-00479.jpg-->
-    
+
 
 
 
@@ -43223,7 +43230,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -43233,7 +43240,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -43290,7 +43297,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -43300,7 +43307,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -43357,7 +43364,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -43367,7 +43374,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -43424,7 +43431,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -43434,7 +43441,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -43491,7 +43498,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -43501,7 +43508,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -43558,7 +43565,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -43568,7 +43575,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -43625,7 +43632,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -43635,7 +43642,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -43692,7 +43699,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -43702,7 +43709,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -43759,7 +43766,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -43769,7 +43776,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -43826,7 +43833,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -43836,7 +43843,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -43878,9 +43885,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00480--mixed4d-00489.jpg-->
-    
+
 
 
 
@@ -44375,7 +44382,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -44385,7 +44392,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -44442,7 +44449,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -44452,7 +44459,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -44509,7 +44516,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -44519,7 +44526,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -44576,7 +44583,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -44586,7 +44593,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -44643,7 +44650,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -44653,7 +44660,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -44710,7 +44717,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -44720,7 +44727,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -44777,7 +44784,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -44787,7 +44794,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -44844,7 +44851,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -44854,7 +44861,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -44911,7 +44918,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -44921,7 +44928,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -44978,7 +44985,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -44988,7 +44995,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -45030,9 +45037,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00490--mixed4d-00499.jpg-->
-    
+
 
 
 
@@ -45537,7 +45544,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -45547,7 +45554,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -45604,7 +45611,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -45614,7 +45621,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -45671,7 +45678,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -45681,7 +45688,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -45738,7 +45745,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -45748,7 +45755,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -45805,7 +45812,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -45815,7 +45822,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -45872,7 +45879,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -45882,7 +45889,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -45939,7 +45946,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -45949,7 +45956,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -46006,7 +46013,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -46016,7 +46023,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -46073,7 +46080,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -46083,7 +46090,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -46140,7 +46147,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -46150,7 +46157,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -46192,9 +46199,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00500--mixed4d-00509.jpg-->
-    
+
 
 
 
@@ -46709,7 +46716,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -46719,7 +46726,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -46776,7 +46783,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -46786,7 +46793,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -46843,7 +46850,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -46853,7 +46860,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -46910,7 +46917,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -46920,7 +46927,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -46977,7 +46984,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -46987,7 +46994,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -47044,7 +47051,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -47054,7 +47061,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -47111,7 +47118,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -47121,7 +47128,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -47178,7 +47185,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -47188,7 +47195,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -47245,7 +47252,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -47255,7 +47262,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -47312,7 +47319,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -47322,7 +47329,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -47364,9 +47371,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00510--mixed4d-00519.jpg-->
-    
+
 
 
 
@@ -47891,7 +47898,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -47901,7 +47908,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -47958,7 +47965,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -47968,7 +47975,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -48025,7 +48032,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -48035,7 +48042,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -48092,7 +48099,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -48102,7 +48109,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -48159,7 +48166,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -48169,7 +48176,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -48226,7 +48233,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -48236,7 +48243,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -48293,7 +48300,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -48303,7 +48310,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -48360,7 +48367,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -48370,7 +48377,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -48427,7 +48434,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -48437,7 +48444,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -48494,7 +48501,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -48504,7 +48511,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -48546,9 +48553,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4d-00520--mixed4d-00527.jpg-->
-    
+
 
 
 
@@ -49083,7 +49090,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -49093,7 +49100,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -49150,7 +49157,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -49160,7 +49167,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -49217,7 +49224,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -49227,7 +49234,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -49284,7 +49291,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -49294,7 +49301,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -49351,7 +49358,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -49361,7 +49368,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -49418,7 +49425,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -49428,7 +49435,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -49485,7 +49492,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -49495,7 +49502,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -49552,7 +49559,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -49562,7 +49569,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -49604,9 +49611,8 @@
       </div>
       </d-figure>
       </li>
-  
+
   </ul>
   </d-article>
   <distill-footer></distill-footer>
 </body>
-  

--- a/public/appendix/googlenet/4e.html
+++ b/public/appendix/googlenet/4e.html
@@ -5,21 +5,21 @@
   <meta charset="utf8">
   <script src="https://distill.pub/template.v2.js"></script>
   <style>
-  
+
     d-article {
       line-height: 1em;
     }
-    
+
     d-byline,
     d-appendix {
       display: none;
     }
-  
+
     h4 {
       display: block;
       width: 100%;
     }
-    
+
     d-figure {
       display: flex;
       flex-flow: row;
@@ -31,7 +31,7 @@
       margin-bottom: 1em;
       justify-content: center;
     }
-    
+
     .positive,
     .negative {
       display: flex;
@@ -40,7 +40,7 @@
       align-content: flex-start;
       max-width: 370px;
     }
-    
+
     .positive {
       padding-left: 1em;
       padding-right: 1em;
@@ -50,14 +50,14 @@
       border-right: 1px solid rgba(0,0,0,0.1);
       justify-content: space-between;
     }
-    
+
     .figcaption {
       display: block;
       color: rgba(0, 0, 0, 0.6);
       font-size: 12px;
       line-height: 1.5em;
     }
-    
+
     .diversity {
       display: flex;
       flex-flow: row;
@@ -65,61 +65,61 @@
       width: 148px;
       height: 147px
     }
-    
+
     .diversity > div {
       zoom: 0.496598639;
     }
-    
+
     .channel {
       margin-right: 1em;
     }
-    
+
     .channels {
       grid-column: screen;
       list-style: none;
       padding-left: 0;
     }
-    
+
     .channels li {
       contain: content;
       overflow: hidden;
     }
-    
+
     .sprite {
       display: inline-block;
       margin: 1px;
       width: 147px;
       height: 147px;
     }
-    
+
     .sprite.neuron {
       background-position-x: 0px;
     }
-    
+
     .sprite.channel {
       background-position-x: -147px;
     }
-    
+
     .sprite.channel-negative {
       background-position-x: -294px;
     }
-    
+
     .sprite.channel-diversity-0 {
       background-position-x: -441px;
     }
-    
+
     .sprite.channel-diversity-1 {
       background-position-x: -588px;
     }
-    
+
     .sprite.channel-diversity-2 {
       background-position-x: -735px;
     }
-    
+
     .sprite.channel-diversity-3 {
       background-position-x: -882px;
     }
-    
+
     .dataset-examples {
       display: flex;
       flex-flow: row;
@@ -127,7 +127,7 @@
       width: 375px;
       height: 147px
     }
-    
+
     .dataset-examples .sprite {
       height: 73px;
       width: 73px;
@@ -136,16 +136,16 @@
       margin-bottom: 0;
       margin-right: 0;
     }
-    
-    
+
+
       .channels .sprite.dataset-index-0 {
         background-position-x: -1029px !important;
       }
-      
+
       .channels .sprite.index-0 {
         background-position-y: -0px;
       }
-      
+
       .channels .dataset-negative .sprite.index-0 {
         background-position-y: -74px !important;
       }
@@ -153,11 +153,11 @@
       .channels .sprite.dataset-index-1 {
         background-position-x: -1103px !important;
       }
-      
+
       .channels .sprite.index-1 {
         background-position-y: -147px;
       }
-      
+
       .channels .dataset-negative .sprite.index-1 {
         background-position-y: -221px !important;
       }
@@ -165,11 +165,11 @@
       .channels .sprite.dataset-index-2 {
         background-position-x: -1177px !important;
       }
-      
+
       .channels .sprite.index-2 {
         background-position-y: -294px;
       }
-      
+
       .channels .dataset-negative .sprite.index-2 {
         background-position-y: -368px !important;
       }
@@ -177,11 +177,11 @@
       .channels .sprite.dataset-index-3 {
         background-position-x: -1251px !important;
       }
-      
+
       .channels .sprite.index-3 {
         background-position-y: -441px;
       }
-      
+
       .channels .dataset-negative .sprite.index-3 {
         background-position-y: -515px !important;
       }
@@ -189,11 +189,11 @@
       .channels .sprite.dataset-index-4 {
         background-position-x: -1325px !important;
       }
-      
+
       .channels .sprite.index-4 {
         background-position-y: -588px;
       }
-      
+
       .channels .dataset-negative .sprite.index-4 {
         background-position-y: -662px !important;
       }
@@ -201,11 +201,11 @@
       .channels .sprite.dataset-index-5 {
         background-position-x: -1399px !important;
       }
-      
+
       .channels .sprite.index-5 {
         background-position-y: -735px;
       }
-      
+
       .channels .dataset-negative .sprite.index-5 {
         background-position-y: -809px !important;
       }
@@ -213,11 +213,11 @@
       .channels .sprite.dataset-index-6 {
         background-position-x: -1473px !important;
       }
-      
+
       .channels .sprite.index-6 {
         background-position-y: -882px;
       }
-      
+
       .channels .dataset-negative .sprite.index-6 {
         background-position-y: -956px !important;
       }
@@ -225,11 +225,11 @@
       .channels .sprite.dataset-index-7 {
         background-position-x: -1547px !important;
       }
-      
+
       .channels .sprite.index-7 {
         background-position-y: -1029px;
       }
-      
+
       .channels .dataset-negative .sprite.index-7 {
         background-position-y: -1103px !important;
       }
@@ -237,11 +237,11 @@
       .channels .sprite.dataset-index-8 {
         background-position-x: -1621px !important;
       }
-      
+
       .channels .sprite.index-8 {
         background-position-y: -1176px;
       }
-      
+
       .channels .dataset-negative .sprite.index-8 {
         background-position-y: -1250px !important;
       }
@@ -249,20 +249,20 @@
       .channels .sprite.dataset-index-9 {
         background-position-x: -1695px !important;
       }
-      
+
       .channels .sprite.index-9 {
         background-position-y: -1323px;
       }
-      
+
       .channels .dataset-negative .sprite.index-9 {
         background-position-y: -1397px !important;
       }
-    
-    
+
+
     .article-nav {
       grid-column: page;
     }
-    
+
     .navlist li {
       display: inline;
       list-style-type: none;
@@ -300,10 +300,10 @@
     <h1>Layer 4e</h1>
   </d-title>
   <d-article>
-  
+
   <nav class="article-nav">
-  
-    
+
+
     <ul class="navlist">
       <li><a href="https://distill.pub/2017/feature-visualization/appendix/">Appendix overview</a></li>
       <li><a href="https://distill.pub/2017/feature-visualization/">Main article</a></li>
@@ -328,7 +328,7 @@
         <a href="4d.html">Layer 4d</a>
       </li>
       <li>
-        <a href="4e.html">Layer 4e</a>
+        <a href="4e.html"><b>Layer 4e</b></a>
       </li>
       <li>
         <a href="5a.html">Layer 5a</a>
@@ -337,14 +337,21 @@
         <a href="5b.html">Layer 5b</a>
       </li>
     </ul>
-  
+
+    <ul class="navlist">
+      <li> <a href="4e.html#4e-0">4e 1x1</a> <span style="color: #777;">(0:256)</span> </li>
+      <li> <a href="4e.html#4e-256">4e 3x3</a> <span style="color: #777;">(256:576)</span> </li>
+      <li> <a href="4e.html#4e-576">4e 5x5</a> <span style="color: #777;">(576:704)</span> </li>
+      <li> <a href="4e.html#4e-704">4e pool</a> <span style="color: #777;">(704:832)</span> </li>
+    </ul>
+
   </nav>
-  
+
   <hr style="margin-top: 20px;"/>
-  
+
   <ul class="channels">
     <!--mixed4e-00000--mixed4e-00009.jpg-->
-    
+
       <li id="channel-0">
       <d-figure id="4e-0">
       <style data-img-src="images/mixed4e-00000--mixed4e-00009.jpg" data-channel="0"></style>
@@ -359,7 +366,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -369,7 +376,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -426,7 +433,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -436,7 +443,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -493,7 +500,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -503,7 +510,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -560,7 +567,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -570,7 +577,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -627,7 +634,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -637,7 +644,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -694,7 +701,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -704,7 +711,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -761,7 +768,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -771,7 +778,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -828,7 +835,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -838,7 +845,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -895,7 +902,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -905,7 +912,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -962,7 +969,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -972,7 +979,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -1014,9 +1021,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00010--mixed4e-00019.jpg-->
-    
+
 
 
 
@@ -1041,7 +1048,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -1051,7 +1058,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -1108,7 +1115,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -1118,7 +1125,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -1175,7 +1182,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -1185,7 +1192,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -1242,7 +1249,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -1252,7 +1259,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -1309,7 +1316,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -1319,7 +1326,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -1376,7 +1383,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -1386,7 +1393,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -1443,7 +1450,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -1453,7 +1460,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -1510,7 +1517,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -1520,7 +1527,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -1577,7 +1584,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -1587,7 +1594,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -1644,7 +1651,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -1654,7 +1661,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -1696,9 +1703,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00020--mixed4e-00029.jpg-->
-    
+
 
 
 
@@ -1733,7 +1740,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -1743,7 +1750,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -1800,7 +1807,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -1810,7 +1817,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -1867,7 +1874,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -1877,7 +1884,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -1934,7 +1941,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -1944,7 +1951,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -2001,7 +2008,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -2011,7 +2018,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -2068,7 +2075,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -2078,7 +2085,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -2135,7 +2142,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -2145,7 +2152,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -2202,7 +2209,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -2212,7 +2219,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -2269,7 +2276,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -2279,7 +2286,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -2336,7 +2343,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -2346,7 +2353,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -2388,9 +2395,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00030--mixed4e-00039.jpg-->
-    
+
 
 
 
@@ -2435,7 +2442,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -2445,7 +2452,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -2502,7 +2509,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -2512,7 +2519,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -2569,7 +2576,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -2579,7 +2586,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -2636,7 +2643,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -2646,7 +2653,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -2703,7 +2710,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -2713,7 +2720,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -2770,7 +2777,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -2780,7 +2787,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -2837,7 +2844,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -2847,7 +2854,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -2904,7 +2911,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -2914,7 +2921,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -2971,7 +2978,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -2981,7 +2988,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -3038,7 +3045,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -3048,7 +3055,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -3090,9 +3097,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00040--mixed4e-00049.jpg-->
-    
+
 
 
 
@@ -3147,7 +3154,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -3157,7 +3164,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -3214,7 +3221,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -3224,7 +3231,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -3281,7 +3288,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -3291,7 +3298,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -3348,7 +3355,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -3358,7 +3365,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -3415,7 +3422,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -3425,7 +3432,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -3482,7 +3489,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -3492,7 +3499,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -3549,7 +3556,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -3559,7 +3566,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -3616,7 +3623,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -3626,7 +3633,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -3683,7 +3690,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -3693,7 +3700,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -3750,7 +3757,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -3760,7 +3767,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -3802,9 +3809,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00050--mixed4e-00059.jpg-->
-    
+
 
 
 
@@ -3869,7 +3876,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -3879,7 +3886,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -3936,7 +3943,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -3946,7 +3953,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -4003,7 +4010,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -4013,7 +4020,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -4070,7 +4077,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -4080,7 +4087,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -4137,7 +4144,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -4147,7 +4154,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -4204,7 +4211,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -4214,7 +4221,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -4271,7 +4278,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -4281,7 +4288,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -4338,7 +4345,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -4348,7 +4355,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -4405,7 +4412,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -4415,7 +4422,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -4472,7 +4479,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -4482,7 +4489,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -4524,9 +4531,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00060--mixed4e-00069.jpg-->
-    
+
 
 
 
@@ -4601,7 +4608,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -4611,7 +4618,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -4668,7 +4675,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -4678,7 +4685,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -4735,7 +4742,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -4745,7 +4752,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -4802,7 +4809,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -4812,7 +4819,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -4869,7 +4876,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -4879,7 +4886,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -4936,7 +4943,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -4946,7 +4953,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -5003,7 +5010,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -5013,7 +5020,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -5070,7 +5077,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -5080,7 +5087,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -5137,7 +5144,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -5147,7 +5154,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -5204,7 +5211,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -5214,7 +5221,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -5256,9 +5263,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00070--mixed4e-00079.jpg-->
-    
+
 
 
 
@@ -5343,7 +5350,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -5353,7 +5360,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -5410,7 +5417,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -5420,7 +5427,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -5477,7 +5484,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -5487,7 +5494,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -5544,7 +5551,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -5554,7 +5561,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -5611,7 +5618,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -5621,7 +5628,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -5678,7 +5685,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -5688,7 +5695,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -5745,7 +5752,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -5755,7 +5762,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -5812,7 +5819,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -5822,7 +5829,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -5879,7 +5886,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -5889,7 +5896,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -5946,7 +5953,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -5956,7 +5963,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -5998,9 +6005,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00080--mixed4e-00089.jpg-->
-    
+
 
 
 
@@ -6095,7 +6102,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -6105,7 +6112,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -6162,7 +6169,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -6172,7 +6179,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -6229,7 +6236,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -6239,7 +6246,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -6296,7 +6303,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -6306,7 +6313,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -6363,7 +6370,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -6373,7 +6380,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -6430,7 +6437,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -6440,7 +6447,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -6497,7 +6504,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -6507,7 +6514,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -6564,7 +6571,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -6574,7 +6581,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -6631,7 +6638,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -6641,7 +6648,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -6698,7 +6705,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -6708,7 +6715,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -6750,9 +6757,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00090--mixed4e-00099.jpg-->
-    
+
 
 
 
@@ -6857,7 +6864,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -6867,7 +6874,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -6924,7 +6931,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -6934,7 +6941,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -6991,7 +6998,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -7001,7 +7008,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -7058,7 +7065,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -7068,7 +7075,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -7125,7 +7132,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -7135,7 +7142,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -7192,7 +7199,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -7202,7 +7209,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -7259,7 +7266,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -7269,7 +7276,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -7326,7 +7333,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -7336,7 +7343,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -7393,7 +7400,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -7403,7 +7410,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -7460,7 +7467,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -7470,7 +7477,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -7512,9 +7519,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00100--mixed4e-00109.jpg-->
-    
+
 
 
 
@@ -7629,7 +7636,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -7639,7 +7646,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -7696,7 +7703,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -7706,7 +7713,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -7763,7 +7770,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -7773,7 +7780,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -7830,7 +7837,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -7840,7 +7847,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -7897,7 +7904,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -7907,7 +7914,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -7964,7 +7971,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -7974,7 +7981,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -8031,7 +8038,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -8041,7 +8048,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -8098,7 +8105,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -8108,7 +8115,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -8165,7 +8172,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -8175,7 +8182,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -8232,7 +8239,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -8242,7 +8249,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -8284,9 +8291,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00110--mixed4e-00119.jpg-->
-    
+
 
 
 
@@ -8411,7 +8418,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -8421,7 +8428,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -8478,7 +8485,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -8488,7 +8495,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -8545,7 +8552,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -8555,7 +8562,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -8612,7 +8619,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -8622,7 +8629,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -8679,7 +8686,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -8689,7 +8696,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -8746,7 +8753,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -8756,7 +8763,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -8813,7 +8820,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -8823,7 +8830,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -8880,7 +8887,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -8890,7 +8897,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -8947,7 +8954,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -8957,7 +8964,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -9014,7 +9021,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -9024,7 +9031,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -9066,9 +9073,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00120--mixed4e-00129.jpg-->
-    
+
 
 
 
@@ -9203,7 +9210,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -9213,7 +9220,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -9270,7 +9277,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -9280,7 +9287,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -9337,7 +9344,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -9347,7 +9354,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -9404,7 +9411,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -9414,7 +9421,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -9471,7 +9478,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -9481,7 +9488,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -9538,7 +9545,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -9548,7 +9555,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -9605,7 +9612,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -9615,7 +9622,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -9672,7 +9679,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -9682,7 +9689,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -9739,7 +9746,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -9749,7 +9756,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -9806,7 +9813,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -9816,7 +9823,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -9858,9 +9865,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00130--mixed4e-00139.jpg-->
-    
+
 
 
 
@@ -10005,7 +10012,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -10015,7 +10022,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -10072,7 +10079,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -10082,7 +10089,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -10139,7 +10146,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -10149,7 +10156,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -10206,7 +10213,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -10216,7 +10223,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -10273,7 +10280,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -10283,7 +10290,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -10340,7 +10347,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -10350,7 +10357,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -10407,7 +10414,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -10417,7 +10424,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -10474,7 +10481,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -10484,7 +10491,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -10541,7 +10548,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -10551,7 +10558,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -10608,7 +10615,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -10618,7 +10625,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -10660,9 +10667,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00140--mixed4e-00149.jpg-->
-    
+
 
 
 
@@ -10817,7 +10824,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -10827,7 +10834,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -10884,7 +10891,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -10894,7 +10901,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -10951,7 +10958,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -10961,7 +10968,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -11018,7 +11025,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -11028,7 +11035,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -11085,7 +11092,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -11095,7 +11102,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -11152,7 +11159,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -11162,7 +11169,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -11219,7 +11226,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -11229,7 +11236,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -11286,7 +11293,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -11296,7 +11303,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -11353,7 +11360,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -11363,7 +11370,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -11420,7 +11427,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -11430,7 +11437,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -11472,9 +11479,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00150--mixed4e-00159.jpg-->
-    
+
 
 
 
@@ -11639,7 +11646,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -11649,7 +11656,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -11706,7 +11713,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -11716,7 +11723,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -11773,7 +11780,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -11783,7 +11790,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -11840,7 +11847,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -11850,7 +11857,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -11907,7 +11914,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -11917,7 +11924,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -11974,7 +11981,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -11984,7 +11991,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -12041,7 +12048,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -12051,7 +12058,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -12108,7 +12115,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -12118,7 +12125,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -12175,7 +12182,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -12185,7 +12192,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -12242,7 +12249,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -12252,7 +12259,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -12294,9 +12301,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00160--mixed4e-00169.jpg-->
-    
+
 
 
 
@@ -12471,7 +12478,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -12481,7 +12488,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -12538,7 +12545,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -12548,7 +12555,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -12605,7 +12612,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -12615,7 +12622,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -12672,7 +12679,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -12682,7 +12689,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -12739,7 +12746,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -12749,7 +12756,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -12806,7 +12813,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -12816,7 +12823,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -12873,7 +12880,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -12883,7 +12890,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -12940,7 +12947,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -12950,7 +12957,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -13007,7 +13014,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -13017,7 +13024,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -13074,7 +13081,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -13084,7 +13091,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -13126,9 +13133,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00170--mixed4e-00179.jpg-->
-    
+
 
 
 
@@ -13313,7 +13320,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -13323,7 +13330,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -13380,7 +13387,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -13390,7 +13397,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -13447,7 +13454,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -13457,7 +13464,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -13514,7 +13521,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -13524,7 +13531,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -13581,7 +13588,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -13591,7 +13598,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -13648,7 +13655,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -13658,7 +13665,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -13715,7 +13722,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -13725,7 +13732,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -13782,7 +13789,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -13792,7 +13799,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -13849,7 +13856,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -13859,7 +13866,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -13916,7 +13923,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -13926,7 +13933,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -13968,9 +13975,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00180--mixed4e-00189.jpg-->
-    
+
 
 
 
@@ -14165,7 +14172,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -14175,7 +14182,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -14232,7 +14239,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -14242,7 +14249,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -14299,7 +14306,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -14309,7 +14316,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -14366,7 +14373,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -14376,7 +14383,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -14433,7 +14440,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -14443,7 +14450,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -14500,7 +14507,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -14510,7 +14517,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -14567,7 +14574,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -14577,7 +14584,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -14634,7 +14641,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -14644,7 +14651,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -14701,7 +14708,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -14711,7 +14718,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -14768,7 +14775,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -14778,7 +14785,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -14820,9 +14827,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00190--mixed4e-00199.jpg-->
-    
+
 
 
 
@@ -15027,7 +15034,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -15037,7 +15044,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -15094,7 +15101,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -15104,7 +15111,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -15161,7 +15168,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -15171,7 +15178,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -15228,7 +15235,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -15238,7 +15245,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -15295,7 +15302,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -15305,7 +15312,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -15362,7 +15369,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -15372,7 +15379,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -15429,7 +15436,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -15439,7 +15446,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -15496,7 +15503,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -15506,7 +15513,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -15563,7 +15570,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -15573,7 +15580,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -15630,7 +15637,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -15640,7 +15647,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -15682,9 +15689,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00200--mixed4e-00209.jpg-->
-    
+
 
 
 
@@ -15899,7 +15906,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -15909,7 +15916,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -15966,7 +15973,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -15976,7 +15983,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -16033,7 +16040,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -16043,7 +16050,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -16100,7 +16107,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -16110,7 +16117,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -16167,7 +16174,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -16177,7 +16184,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -16234,7 +16241,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -16244,7 +16251,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -16301,7 +16308,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -16311,7 +16318,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -16368,7 +16375,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -16378,7 +16385,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -16435,7 +16442,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -16445,7 +16452,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -16502,7 +16509,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -16512,7 +16519,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -16554,9 +16561,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00210--mixed4e-00219.jpg-->
-    
+
 
 
 
@@ -16781,7 +16788,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -16791,7 +16798,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -16848,7 +16855,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -16858,7 +16865,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -16915,7 +16922,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -16925,7 +16932,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -16982,7 +16989,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -16992,7 +16999,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -17049,7 +17056,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -17059,7 +17066,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -17116,7 +17123,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -17126,7 +17133,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -17183,7 +17190,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -17193,7 +17200,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -17250,7 +17257,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -17260,7 +17267,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -17317,7 +17324,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -17327,7 +17334,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -17384,7 +17391,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -17394,7 +17401,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -17436,9 +17443,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00220--mixed4e-00229.jpg-->
-    
+
 
 
 
@@ -17673,7 +17680,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -17683,7 +17690,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -17740,7 +17747,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -17750,7 +17757,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -17807,7 +17814,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -17817,7 +17824,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -17874,7 +17881,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -17884,7 +17891,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -17941,7 +17948,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -17951,7 +17958,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -18008,7 +18015,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -18018,7 +18025,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -18075,7 +18082,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -18085,7 +18092,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -18142,7 +18149,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -18152,7 +18159,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -18209,7 +18216,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -18219,7 +18226,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -18276,7 +18283,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -18286,7 +18293,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -18328,9 +18335,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00230--mixed4e-00239.jpg-->
-    
+
 
 
 
@@ -18575,7 +18582,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -18585,7 +18592,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -18642,7 +18649,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -18652,7 +18659,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -18709,7 +18716,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -18719,7 +18726,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -18776,7 +18783,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -18786,7 +18793,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -18843,7 +18850,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -18853,7 +18860,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -18910,7 +18917,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -18920,7 +18927,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -18977,7 +18984,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -18987,7 +18994,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -19044,7 +19051,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -19054,7 +19061,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -19111,7 +19118,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -19121,7 +19128,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -19178,7 +19185,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -19188,7 +19195,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -19230,9 +19237,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00240--mixed4e-00249.jpg-->
-    
+
 
 
 
@@ -19487,7 +19494,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -19497,7 +19504,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -19554,7 +19561,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -19564,7 +19571,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -19621,7 +19628,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -19631,7 +19638,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -19688,7 +19695,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -19698,7 +19705,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -19755,7 +19762,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -19765,7 +19772,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -19822,7 +19829,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -19832,7 +19839,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -19889,7 +19896,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -19899,7 +19906,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -19956,7 +19963,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -19966,7 +19973,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -20023,7 +20030,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -20033,7 +20040,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -20090,7 +20097,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -20100,7 +20107,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -20142,9 +20149,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00250--mixed4e-00259.jpg-->
-    
+
 
 
 
@@ -20409,7 +20416,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -20419,7 +20426,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -20476,7 +20483,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -20486,7 +20493,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -20543,7 +20550,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -20553,7 +20560,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -20610,7 +20617,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -20620,7 +20627,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -20677,7 +20684,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -20687,7 +20694,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -20744,7 +20751,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -20754,7 +20761,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -20811,7 +20818,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -20821,7 +20828,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -20878,7 +20885,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -20888,7 +20895,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -20945,7 +20952,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -20955,7 +20962,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -21012,7 +21019,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -21022,7 +21029,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -21064,9 +21071,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00260--mixed4e-00269.jpg-->
-    
+
 
 
 
@@ -21341,7 +21348,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -21351,7 +21358,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -21408,7 +21415,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -21418,7 +21425,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -21475,7 +21482,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -21485,7 +21492,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -21542,7 +21549,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -21552,7 +21559,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -21609,7 +21616,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -21619,7 +21626,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -21676,7 +21683,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -21686,7 +21693,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -21743,7 +21750,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -21753,7 +21760,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -21810,7 +21817,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -21820,7 +21827,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -21877,7 +21884,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -21887,7 +21894,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -21944,7 +21951,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -21954,7 +21961,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -21996,9 +22003,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00270--mixed4e-00279.jpg-->
-    
+
 
 
 
@@ -22283,7 +22290,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -22293,7 +22300,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -22350,7 +22357,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -22360,7 +22367,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -22417,7 +22424,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -22427,7 +22434,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -22484,7 +22491,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -22494,7 +22501,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -22551,7 +22558,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -22561,7 +22568,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -22618,7 +22625,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -22628,7 +22635,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -22685,7 +22692,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -22695,7 +22702,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -22752,7 +22759,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -22762,7 +22769,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -22819,7 +22826,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -22829,7 +22836,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -22886,7 +22893,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -22896,7 +22903,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -22938,9 +22945,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00280--mixed4e-00289.jpg-->
-    
+
 
 
 
@@ -23235,7 +23242,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -23245,7 +23252,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -23302,7 +23309,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -23312,7 +23319,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -23369,7 +23376,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -23379,7 +23386,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -23436,7 +23443,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -23446,7 +23453,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -23503,7 +23510,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -23513,7 +23520,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -23570,7 +23577,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -23580,7 +23587,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -23637,7 +23644,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -23647,7 +23654,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -23704,7 +23711,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -23714,7 +23721,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -23771,7 +23778,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -23781,7 +23788,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -23838,7 +23845,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -23848,7 +23855,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -23890,9 +23897,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00290--mixed4e-00299.jpg-->
-    
+
 
 
 
@@ -24197,7 +24204,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -24207,7 +24214,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -24264,7 +24271,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -24274,7 +24281,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -24331,7 +24338,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -24341,7 +24348,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -24398,7 +24405,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -24408,7 +24415,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -24465,7 +24472,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -24475,7 +24482,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -24532,7 +24539,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -24542,7 +24549,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -24599,7 +24606,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -24609,7 +24616,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -24666,7 +24673,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -24676,7 +24683,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -24733,7 +24740,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -24743,7 +24750,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -24800,7 +24807,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -24810,7 +24817,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -24852,9 +24859,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00300--mixed4e-00309.jpg-->
-    
+
 
 
 
@@ -25169,7 +25176,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -25179,7 +25186,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -25236,7 +25243,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -25246,7 +25253,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -25303,7 +25310,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -25313,7 +25320,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -25370,7 +25377,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -25380,7 +25387,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -25437,7 +25444,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -25447,7 +25454,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -25504,7 +25511,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -25514,7 +25521,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -25571,7 +25578,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -25581,7 +25588,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -25638,7 +25645,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -25648,7 +25655,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -25705,7 +25712,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -25715,7 +25722,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -25772,7 +25779,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -25782,7 +25789,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -25824,9 +25831,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00310--mixed4e-00319.jpg-->
-    
+
 
 
 
@@ -26151,7 +26158,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -26161,7 +26168,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -26218,7 +26225,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -26228,7 +26235,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -26285,7 +26292,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -26295,7 +26302,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -26352,7 +26359,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -26362,7 +26369,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -26419,7 +26426,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -26429,7 +26436,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -26486,7 +26493,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -26496,7 +26503,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -26553,7 +26560,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -26563,7 +26570,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -26620,7 +26627,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -26630,7 +26637,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -26687,7 +26694,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -26697,7 +26704,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -26754,7 +26761,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -26764,7 +26771,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -26806,9 +26813,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00320--mixed4e-00329.jpg-->
-    
+
 
 
 
@@ -27143,7 +27150,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -27153,7 +27160,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -27210,7 +27217,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -27220,7 +27227,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -27277,7 +27284,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -27287,7 +27294,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -27344,7 +27351,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -27354,7 +27361,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -27411,7 +27418,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -27421,7 +27428,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -27478,7 +27485,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -27488,7 +27495,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -27545,7 +27552,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -27555,7 +27562,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -27612,7 +27619,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -27622,7 +27629,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -27679,7 +27686,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -27689,7 +27696,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -27746,7 +27753,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -27756,7 +27763,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -27798,9 +27805,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00330--mixed4e-00339.jpg-->
-    
+
 
 
 
@@ -28145,7 +28152,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -28155,7 +28162,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -28212,7 +28219,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -28222,7 +28229,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -28279,7 +28286,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -28289,7 +28296,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -28346,7 +28353,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -28356,7 +28363,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -28413,7 +28420,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -28423,7 +28430,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -28480,7 +28487,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -28490,7 +28497,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -28547,7 +28554,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -28557,7 +28564,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -28614,7 +28621,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -28624,7 +28631,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -28681,7 +28688,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -28691,7 +28698,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -28748,7 +28755,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -28758,7 +28765,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -28800,9 +28807,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00340--mixed4e-00349.jpg-->
-    
+
 
 
 
@@ -29157,7 +29164,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -29167,7 +29174,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -29224,7 +29231,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -29234,7 +29241,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -29291,7 +29298,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -29301,7 +29308,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -29358,7 +29365,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -29368,7 +29375,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -29425,7 +29432,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -29435,7 +29442,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -29492,7 +29499,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -29502,7 +29509,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -29559,7 +29566,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -29569,7 +29576,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -29626,7 +29633,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -29636,7 +29643,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -29693,7 +29700,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -29703,7 +29710,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -29760,7 +29767,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -29770,7 +29777,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -29812,9 +29819,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00350--mixed4e-00359.jpg-->
-    
+
 
 
 
@@ -30179,7 +30186,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -30189,7 +30196,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -30246,7 +30253,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -30256,7 +30263,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -30313,7 +30320,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -30323,7 +30330,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -30380,7 +30387,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -30390,7 +30397,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -30447,7 +30454,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -30457,7 +30464,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -30514,7 +30521,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -30524,7 +30531,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -30581,7 +30588,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -30591,7 +30598,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -30648,7 +30655,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -30658,7 +30665,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -30715,7 +30722,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -30725,7 +30732,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -30782,7 +30789,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -30792,7 +30799,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -30834,9 +30841,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00360--mixed4e-00369.jpg-->
-    
+
 
 
 
@@ -31211,7 +31218,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -31221,7 +31228,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -31278,7 +31285,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -31288,7 +31295,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -31345,7 +31352,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -31355,7 +31362,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -31412,7 +31419,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -31422,7 +31429,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -31479,7 +31486,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -31489,7 +31496,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -31546,7 +31553,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -31556,7 +31563,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -31613,7 +31620,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -31623,7 +31630,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -31680,7 +31687,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -31690,7 +31697,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -31747,7 +31754,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -31757,7 +31764,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -31814,7 +31821,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -31824,7 +31831,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -31866,9 +31873,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00370--mixed4e-00379.jpg-->
-    
+
 
 
 
@@ -32253,7 +32260,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -32263,7 +32270,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -32320,7 +32327,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -32330,7 +32337,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -32387,7 +32394,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -32397,7 +32404,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -32454,7 +32461,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -32464,7 +32471,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -32521,7 +32528,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -32531,7 +32538,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -32588,7 +32595,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -32598,7 +32605,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -32655,7 +32662,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -32665,7 +32672,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -32722,7 +32729,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -32732,7 +32739,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -32789,7 +32796,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -32799,7 +32806,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -32856,7 +32863,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -32866,7 +32873,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -32908,9 +32915,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00380--mixed4e-00389.jpg-->
-    
+
 
 
 
@@ -33305,7 +33312,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -33315,7 +33322,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -33372,7 +33379,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -33382,7 +33389,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -33439,7 +33446,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -33449,7 +33456,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -33506,7 +33513,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -33516,7 +33523,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -33573,7 +33580,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -33583,7 +33590,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -33640,7 +33647,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -33650,7 +33657,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -33707,7 +33714,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -33717,7 +33724,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -33774,7 +33781,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -33784,7 +33791,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -33841,7 +33848,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -33851,7 +33858,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -33908,7 +33915,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -33918,7 +33925,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -33960,9 +33967,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00390--mixed4e-00399.jpg-->
-    
+
 
 
 
@@ -34367,7 +34374,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -34377,7 +34384,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -34434,7 +34441,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -34444,7 +34451,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -34501,7 +34508,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -34511,7 +34518,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -34568,7 +34575,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -34578,7 +34585,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -34635,7 +34642,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -34645,7 +34652,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -34702,7 +34709,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -34712,7 +34719,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -34769,7 +34776,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -34779,7 +34786,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -34836,7 +34843,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -34846,7 +34853,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -34903,7 +34910,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -34913,7 +34920,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -34970,7 +34977,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -34980,7 +34987,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -35022,9 +35029,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00400--mixed4e-00409.jpg-->
-    
+
 
 
 
@@ -35439,7 +35446,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -35449,7 +35456,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -35506,7 +35513,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -35516,7 +35523,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -35573,7 +35580,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -35583,7 +35590,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -35640,7 +35647,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -35650,7 +35657,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -35707,7 +35714,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -35717,7 +35724,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -35774,7 +35781,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -35784,7 +35791,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -35841,7 +35848,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -35851,7 +35858,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -35908,7 +35915,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -35918,7 +35925,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -35975,7 +35982,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -35985,7 +35992,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -36042,7 +36049,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -36052,7 +36059,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -36094,9 +36101,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00410--mixed4e-00419.jpg-->
-    
+
 
 
 
@@ -36521,7 +36528,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -36531,7 +36538,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -36588,7 +36595,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -36598,7 +36605,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -36655,7 +36662,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -36665,7 +36672,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -36722,7 +36729,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -36732,7 +36739,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -36789,7 +36796,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -36799,7 +36806,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -36856,7 +36863,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -36866,7 +36873,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -36923,7 +36930,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -36933,7 +36940,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -36990,7 +36997,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -37000,7 +37007,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -37057,7 +37064,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -37067,7 +37074,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -37124,7 +37131,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -37134,7 +37141,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -37176,9 +37183,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00420--mixed4e-00429.jpg-->
-    
+
 
 
 
@@ -37613,7 +37620,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -37623,7 +37630,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -37680,7 +37687,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -37690,7 +37697,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -37747,7 +37754,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -37757,7 +37764,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -37814,7 +37821,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -37824,7 +37831,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -37881,7 +37888,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -37891,7 +37898,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -37948,7 +37955,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -37958,7 +37965,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -38015,7 +38022,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -38025,7 +38032,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -38082,7 +38089,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -38092,7 +38099,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -38149,7 +38156,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -38159,7 +38166,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -38216,7 +38223,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -38226,7 +38233,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -38268,9 +38275,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00430--mixed4e-00439.jpg-->
-    
+
 
 
 
@@ -38715,7 +38722,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -38725,7 +38732,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -38782,7 +38789,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -38792,7 +38799,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -38849,7 +38856,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -38859,7 +38866,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -38916,7 +38923,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -38926,7 +38933,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -38983,7 +38990,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -38993,7 +39000,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -39050,7 +39057,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -39060,7 +39067,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -39117,7 +39124,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -39127,7 +39134,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -39184,7 +39191,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -39194,7 +39201,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -39251,7 +39258,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -39261,7 +39268,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -39318,7 +39325,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -39328,7 +39335,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -39370,9 +39377,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00440--mixed4e-00449.jpg-->
-    
+
 
 
 
@@ -39827,7 +39834,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -39837,7 +39844,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -39894,7 +39901,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -39904,7 +39911,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -39961,7 +39968,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -39971,7 +39978,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -40028,7 +40035,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -40038,7 +40045,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -40095,7 +40102,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -40105,7 +40112,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -40162,7 +40169,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -40172,7 +40179,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -40229,7 +40236,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -40239,7 +40246,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -40296,7 +40303,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -40306,7 +40313,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -40363,7 +40370,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -40373,7 +40380,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -40430,7 +40437,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -40440,7 +40447,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -40482,9 +40489,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00450--mixed4e-00459.jpg-->
-    
+
 
 
 
@@ -40949,7 +40956,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -40959,7 +40966,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -41016,7 +41023,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -41026,7 +41033,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -41083,7 +41090,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -41093,7 +41100,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -41150,7 +41157,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -41160,7 +41167,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -41217,7 +41224,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -41227,7 +41234,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -41284,7 +41291,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -41294,7 +41301,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -41351,7 +41358,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -41361,7 +41368,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -41418,7 +41425,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -41428,7 +41435,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -41485,7 +41492,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -41495,7 +41502,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -41552,7 +41559,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -41562,7 +41569,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -41604,9 +41611,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00460--mixed4e-00469.jpg-->
-    
+
 
 
 
@@ -42081,7 +42088,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -42091,7 +42098,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -42148,7 +42155,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -42158,7 +42165,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -42215,7 +42222,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -42225,7 +42232,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -42282,7 +42289,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -42292,7 +42299,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -42349,7 +42356,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -42359,7 +42366,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -42416,7 +42423,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -42426,7 +42433,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -42483,7 +42490,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -42493,7 +42500,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -42550,7 +42557,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -42560,7 +42567,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -42617,7 +42624,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -42627,7 +42634,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -42684,7 +42691,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -42694,7 +42701,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -42736,9 +42743,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00470--mixed4e-00479.jpg-->
-    
+
 
 
 
@@ -43223,7 +43230,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -43233,7 +43240,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -43290,7 +43297,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -43300,7 +43307,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -43357,7 +43364,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -43367,7 +43374,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -43424,7 +43431,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -43434,7 +43441,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -43491,7 +43498,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -43501,7 +43508,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -43558,7 +43565,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -43568,7 +43575,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -43625,7 +43632,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -43635,7 +43642,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -43692,7 +43699,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -43702,7 +43709,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -43759,7 +43766,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -43769,7 +43776,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -43826,7 +43833,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -43836,7 +43843,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -43878,9 +43885,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00480--mixed4e-00489.jpg-->
-    
+
 
 
 
@@ -44375,7 +44382,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -44385,7 +44392,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -44442,7 +44449,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -44452,7 +44459,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -44509,7 +44516,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -44519,7 +44526,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -44576,7 +44583,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -44586,7 +44593,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -44643,7 +44650,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -44653,7 +44660,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -44710,7 +44717,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -44720,7 +44727,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -44777,7 +44784,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -44787,7 +44794,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -44844,7 +44851,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -44854,7 +44861,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -44911,7 +44918,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -44921,7 +44928,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -44978,7 +44985,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -44988,7 +44995,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -45030,9 +45037,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00490--mixed4e-00499.jpg-->
-    
+
 
 
 
@@ -45537,7 +45544,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -45547,7 +45554,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -45604,7 +45611,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -45614,7 +45621,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -45671,7 +45678,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -45681,7 +45688,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -45738,7 +45745,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -45748,7 +45755,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -45805,7 +45812,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -45815,7 +45822,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -45872,7 +45879,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -45882,7 +45889,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -45939,7 +45946,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -45949,7 +45956,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -46006,7 +46013,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -46016,7 +46023,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -46073,7 +46080,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -46083,7 +46090,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -46140,7 +46147,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -46150,7 +46157,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -46192,9 +46199,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00500--mixed4e-00509.jpg-->
-    
+
 
 
 
@@ -46709,7 +46716,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -46719,7 +46726,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -46776,7 +46783,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -46786,7 +46793,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -46843,7 +46850,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -46853,7 +46860,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -46910,7 +46917,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -46920,7 +46927,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -46977,7 +46984,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -46987,7 +46994,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -47044,7 +47051,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -47054,7 +47061,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -47111,7 +47118,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -47121,7 +47128,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -47178,7 +47185,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -47188,7 +47195,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -47245,7 +47252,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -47255,7 +47262,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -47312,7 +47319,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -47322,7 +47329,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -47364,9 +47371,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00510--mixed4e-00519.jpg-->
-    
+
 
 
 
@@ -47891,7 +47898,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -47901,7 +47908,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -47958,7 +47965,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -47968,7 +47975,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -48025,7 +48032,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -48035,7 +48042,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -48092,7 +48099,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -48102,7 +48109,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -48159,7 +48166,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -48169,7 +48176,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -48226,7 +48233,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -48236,7 +48243,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -48293,7 +48300,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -48303,7 +48310,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -48360,7 +48367,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -48370,7 +48377,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -48427,7 +48434,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -48437,7 +48444,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -48494,7 +48501,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -48504,7 +48511,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -48546,9 +48553,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00520--mixed4e-00529.jpg-->
-    
+
 
 
 
@@ -49083,7 +49090,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -49093,7 +49100,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -49150,7 +49157,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -49160,7 +49167,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -49217,7 +49224,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -49227,7 +49234,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -49284,7 +49291,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -49294,7 +49301,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -49351,7 +49358,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -49361,7 +49368,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -49418,7 +49425,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -49428,7 +49435,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -49485,7 +49492,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -49495,7 +49502,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -49552,7 +49559,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -49562,7 +49569,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -49619,7 +49626,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -49629,7 +49636,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -49686,7 +49693,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -49696,7 +49703,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -49738,9 +49745,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00530--mixed4e-00539.jpg-->
-    
+
 
 
 
@@ -50285,7 +50292,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -50295,7 +50302,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -50352,7 +50359,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -50362,7 +50369,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -50419,7 +50426,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -50429,7 +50436,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -50486,7 +50493,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -50496,7 +50503,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -50553,7 +50560,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -50563,7 +50570,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -50620,7 +50627,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -50630,7 +50637,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -50687,7 +50694,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -50697,7 +50704,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -50754,7 +50761,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -50764,7 +50771,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -50821,7 +50828,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -50831,7 +50838,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -50888,7 +50895,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -50898,7 +50905,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -50940,9 +50947,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00540--mixed4e-00549.jpg-->
-    
+
 
 
 
@@ -51497,7 +51504,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -51507,7 +51514,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -51564,7 +51571,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -51574,7 +51581,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -51631,7 +51638,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -51641,7 +51648,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -51698,7 +51705,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -51708,7 +51715,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -51765,7 +51772,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -51775,7 +51782,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -51832,7 +51839,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -51842,7 +51849,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -51899,7 +51906,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -51909,7 +51916,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -51966,7 +51973,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -51976,7 +51983,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -52033,7 +52040,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -52043,7 +52050,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -52100,7 +52107,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -52110,7 +52117,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -52152,9 +52159,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00550--mixed4e-00559.jpg-->
-    
+
 
 
 
@@ -52719,7 +52726,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -52729,7 +52736,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -52786,7 +52793,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -52796,7 +52803,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -52853,7 +52860,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -52863,7 +52870,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -52920,7 +52927,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -52930,7 +52937,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -52987,7 +52994,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -52997,7 +53004,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -53054,7 +53061,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -53064,7 +53071,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -53121,7 +53128,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -53131,7 +53138,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -53188,7 +53195,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -53198,7 +53205,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -53255,7 +53262,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -53265,7 +53272,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -53322,7 +53329,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -53332,7 +53339,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -53374,9 +53381,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00560--mixed4e-00569.jpg-->
-    
+
 
 
 
@@ -53951,7 +53958,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -53961,7 +53968,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -54018,7 +54025,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -54028,7 +54035,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -54085,7 +54092,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -54095,7 +54102,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -54152,7 +54159,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -54162,7 +54169,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -54219,7 +54226,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -54229,7 +54236,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -54286,7 +54293,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -54296,7 +54303,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -54353,7 +54360,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -54363,7 +54370,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -54420,7 +54427,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -54430,7 +54437,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -54487,7 +54494,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -54497,7 +54504,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -54554,7 +54561,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -54564,7 +54571,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -54606,9 +54613,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00570--mixed4e-00579.jpg-->
-    
+
 
 
 
@@ -55193,7 +55200,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -55203,7 +55210,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -55260,7 +55267,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -55270,7 +55277,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -55327,7 +55334,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -55337,7 +55344,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -55394,7 +55401,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -55404,7 +55411,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -55461,7 +55468,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -55471,7 +55478,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -55528,7 +55535,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -55538,7 +55545,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -55595,7 +55602,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -55605,7 +55612,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -55662,7 +55669,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -55672,7 +55679,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -55729,7 +55736,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -55739,7 +55746,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -55796,7 +55803,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -55806,7 +55813,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -55848,9 +55855,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00580--mixed4e-00589.jpg-->
-    
+
 
 
 
@@ -56445,7 +56452,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -56455,7 +56462,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -56512,7 +56519,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -56522,7 +56529,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -56579,7 +56586,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -56589,7 +56596,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -56646,7 +56653,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -56656,7 +56663,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -56713,7 +56720,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -56723,7 +56730,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -56780,7 +56787,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -56790,7 +56797,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -56847,7 +56854,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -56857,7 +56864,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -56914,7 +56921,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -56924,7 +56931,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -56981,7 +56988,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -56991,7 +56998,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -57048,7 +57055,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -57058,7 +57065,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -57100,9 +57107,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00590--mixed4e-00599.jpg-->
-    
+
 
 
 
@@ -57707,7 +57714,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -57717,7 +57724,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -57774,7 +57781,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -57784,7 +57791,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -57841,7 +57848,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -57851,7 +57858,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -57908,7 +57915,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -57918,7 +57925,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -57975,7 +57982,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -57985,7 +57992,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -58042,7 +58049,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -58052,7 +58059,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -58109,7 +58116,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -58119,7 +58126,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -58176,7 +58183,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -58186,7 +58193,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -58243,7 +58250,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -58253,7 +58260,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -58310,7 +58317,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -58320,7 +58327,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -58362,9 +58369,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00600--mixed4e-00609.jpg-->
-    
+
 
 
 
@@ -58979,7 +58986,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -58989,7 +58996,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -59046,7 +59053,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -59056,7 +59063,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -59113,7 +59120,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -59123,7 +59130,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -59180,7 +59187,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -59190,7 +59197,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -59247,7 +59254,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -59257,7 +59264,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -59314,7 +59321,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -59324,7 +59331,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -59381,7 +59388,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -59391,7 +59398,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -59448,7 +59455,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -59458,7 +59465,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -59515,7 +59522,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -59525,7 +59532,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -59582,7 +59589,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -59592,7 +59599,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -59634,9 +59641,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00610--mixed4e-00619.jpg-->
-    
+
 
 
 
@@ -60261,7 +60268,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -60271,7 +60278,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -60328,7 +60335,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -60338,7 +60345,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -60395,7 +60402,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -60405,7 +60412,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -60462,7 +60469,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -60472,7 +60479,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -60529,7 +60536,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -60539,7 +60546,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -60596,7 +60603,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -60606,7 +60613,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -60663,7 +60670,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -60673,7 +60680,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -60730,7 +60737,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -60740,7 +60747,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -60797,7 +60804,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -60807,7 +60814,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -60864,7 +60871,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -60874,7 +60881,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -60916,9 +60923,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00620--mixed4e-00629.jpg-->
-    
+
 
 
 
@@ -61553,7 +61560,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -61563,7 +61570,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -61620,7 +61627,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -61630,7 +61637,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -61687,7 +61694,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -61697,7 +61704,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -61754,7 +61761,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -61764,7 +61771,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -61821,7 +61828,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -61831,7 +61838,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -61888,7 +61895,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -61898,7 +61905,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -61955,7 +61962,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -61965,7 +61972,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -62022,7 +62029,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -62032,7 +62039,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -62089,7 +62096,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -62099,7 +62106,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -62156,7 +62163,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -62166,7 +62173,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -62208,9 +62215,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00630--mixed4e-00639.jpg-->
-    
+
 
 
 
@@ -62855,7 +62862,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -62865,7 +62872,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -62922,7 +62929,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -62932,7 +62939,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -62989,7 +62996,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -62999,7 +63006,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -63056,7 +63063,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -63066,7 +63073,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -63123,7 +63130,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -63133,7 +63140,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -63190,7 +63197,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -63200,7 +63207,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -63257,7 +63264,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -63267,7 +63274,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -63324,7 +63331,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -63334,7 +63341,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -63391,7 +63398,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -63401,7 +63408,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -63458,7 +63465,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -63468,7 +63475,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -63510,9 +63517,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00640--mixed4e-00649.jpg-->
-    
+
 
 
 
@@ -64167,7 +64174,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -64177,7 +64184,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -64234,7 +64241,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -64244,7 +64251,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -64301,7 +64308,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -64311,7 +64318,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -64368,7 +64375,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -64378,7 +64385,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -64435,7 +64442,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -64445,7 +64452,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -64502,7 +64509,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -64512,7 +64519,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -64569,7 +64576,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -64579,7 +64586,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -64636,7 +64643,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -64646,7 +64653,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -64703,7 +64710,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -64713,7 +64720,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -64770,7 +64777,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -64780,7 +64787,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -64822,9 +64829,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00650--mixed4e-00659.jpg-->
-    
+
 
 
 
@@ -65489,7 +65496,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -65499,7 +65506,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -65556,7 +65563,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -65566,7 +65573,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -65623,7 +65630,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -65633,7 +65640,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -65690,7 +65697,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -65700,7 +65707,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -65757,7 +65764,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -65767,7 +65774,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -65824,7 +65831,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -65834,7 +65841,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -65891,7 +65898,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -65901,7 +65908,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -65958,7 +65965,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -65968,7 +65975,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -66025,7 +66032,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -66035,7 +66042,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -66092,7 +66099,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -66102,7 +66109,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -66144,9 +66151,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00660--mixed4e-00669.jpg-->
-    
+
 
 
 
@@ -66821,7 +66828,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -66831,7 +66838,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -66888,7 +66895,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -66898,7 +66905,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -66955,7 +66962,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -66965,7 +66972,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -67022,7 +67029,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -67032,7 +67039,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -67089,7 +67096,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -67099,7 +67106,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -67156,7 +67163,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -67166,7 +67173,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -67223,7 +67230,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -67233,7 +67240,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -67290,7 +67297,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -67300,7 +67307,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -67357,7 +67364,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -67367,7 +67374,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -67424,7 +67431,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -67434,7 +67441,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -67476,9 +67483,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00670--mixed4e-00679.jpg-->
-    
+
 
 
 
@@ -68163,7 +68170,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -68173,7 +68180,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -68230,7 +68237,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -68240,7 +68247,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -68297,7 +68304,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -68307,7 +68314,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -68364,7 +68371,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -68374,7 +68381,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -68431,7 +68438,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -68441,7 +68448,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -68498,7 +68505,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -68508,7 +68515,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -68565,7 +68572,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -68575,7 +68582,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -68632,7 +68639,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -68642,7 +68649,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -68699,7 +68706,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -68709,7 +68716,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -68766,7 +68773,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -68776,7 +68783,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -68818,9 +68825,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00680--mixed4e-00689.jpg-->
-    
+
 
 
 
@@ -69515,7 +69522,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -69525,7 +69532,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -69582,7 +69589,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -69592,7 +69599,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -69649,7 +69656,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -69659,7 +69666,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -69716,7 +69723,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -69726,7 +69733,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -69783,7 +69790,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -69793,7 +69800,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -69850,7 +69857,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -69860,7 +69867,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -69917,7 +69924,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -69927,7 +69934,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -69984,7 +69991,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -69994,7 +70001,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -70051,7 +70058,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -70061,7 +70068,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -70118,7 +70125,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -70128,7 +70135,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -70170,9 +70177,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00690--mixed4e-00699.jpg-->
-    
+
 
 
 
@@ -70877,7 +70884,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -70887,7 +70894,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -70944,7 +70951,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -70954,7 +70961,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -71011,7 +71018,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -71021,7 +71028,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -71078,7 +71085,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -71088,7 +71095,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -71145,7 +71152,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -71155,7 +71162,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -71212,7 +71219,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -71222,7 +71229,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -71279,7 +71286,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -71289,7 +71296,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -71346,7 +71353,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -71356,7 +71363,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -71413,7 +71420,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -71423,7 +71430,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -71480,7 +71487,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -71490,7 +71497,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -71532,9 +71539,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00700--mixed4e-00709.jpg-->
-    
+
 
 
 
@@ -72249,7 +72256,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -72259,7 +72266,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -72316,7 +72323,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -72326,7 +72333,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -72383,7 +72390,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -72393,7 +72400,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -72450,7 +72457,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -72460,7 +72467,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -72517,7 +72524,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -72527,7 +72534,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -72584,7 +72591,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -72594,7 +72601,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -72651,7 +72658,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -72661,7 +72668,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -72718,7 +72725,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -72728,7 +72735,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -72785,7 +72792,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -72795,7 +72802,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -72852,7 +72859,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -72862,7 +72869,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -72904,9 +72911,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00710--mixed4e-00719.jpg-->
-    
+
 
 
 
@@ -73631,7 +73638,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -73641,7 +73648,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -73698,7 +73705,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -73708,7 +73715,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -73765,7 +73772,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -73775,7 +73782,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -73832,7 +73839,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -73842,7 +73849,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -73899,7 +73906,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -73909,7 +73916,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -73966,7 +73973,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -73976,7 +73983,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -74033,7 +74040,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -74043,7 +74050,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -74100,7 +74107,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -74110,7 +74117,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -74167,7 +74174,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -74177,7 +74184,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -74234,7 +74241,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -74244,7 +74251,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -74286,9 +74293,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00720--mixed4e-00729.jpg-->
-    
+
 
 
 
@@ -75023,7 +75030,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -75033,7 +75040,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -75090,7 +75097,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -75100,7 +75107,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -75157,7 +75164,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -75167,7 +75174,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -75224,7 +75231,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -75234,7 +75241,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -75291,7 +75298,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -75301,7 +75308,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -75358,7 +75365,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -75368,7 +75375,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -75425,7 +75432,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -75435,7 +75442,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -75492,7 +75499,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -75502,7 +75509,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -75559,7 +75566,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -75569,7 +75576,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -75626,7 +75633,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -75636,7 +75643,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -75678,9 +75685,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00730--mixed4e-00739.jpg-->
-    
+
 
 
 
@@ -76425,7 +76432,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -76435,7 +76442,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -76492,7 +76499,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -76502,7 +76509,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -76559,7 +76566,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -76569,7 +76576,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -76626,7 +76633,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -76636,7 +76643,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -76693,7 +76700,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -76703,7 +76710,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -76760,7 +76767,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -76770,7 +76777,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -76827,7 +76834,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -76837,7 +76844,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -76894,7 +76901,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -76904,7 +76911,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -76961,7 +76968,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -76971,7 +76978,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -77028,7 +77035,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -77038,7 +77045,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -77080,9 +77087,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00740--mixed4e-00749.jpg-->
-    
+
 
 
 
@@ -77837,7 +77844,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -77847,7 +77854,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -77904,7 +77911,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -77914,7 +77921,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -77971,7 +77978,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -77981,7 +77988,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -78038,7 +78045,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -78048,7 +78055,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -78105,7 +78112,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -78115,7 +78122,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -78172,7 +78179,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -78182,7 +78189,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -78239,7 +78246,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -78249,7 +78256,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -78306,7 +78313,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -78316,7 +78323,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -78373,7 +78380,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -78383,7 +78390,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -78440,7 +78447,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -78450,7 +78457,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -78492,9 +78499,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00750--mixed4e-00759.jpg-->
-    
+
 
 
 
@@ -79259,7 +79266,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -79269,7 +79276,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -79326,7 +79333,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -79336,7 +79343,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -79393,7 +79400,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -79403,7 +79410,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -79460,7 +79467,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -79470,7 +79477,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -79527,7 +79534,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -79537,7 +79544,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -79594,7 +79601,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -79604,7 +79611,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -79661,7 +79668,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -79671,7 +79678,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -79728,7 +79735,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -79738,7 +79745,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -79795,7 +79802,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -79805,7 +79812,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -79862,7 +79869,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -79872,7 +79879,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -79914,9 +79921,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00760--mixed4e-00769.jpg-->
-    
+
 
 
 
@@ -80691,7 +80698,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -80701,7 +80708,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -80758,7 +80765,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -80768,7 +80775,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -80825,7 +80832,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -80835,7 +80842,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -80892,7 +80899,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -80902,7 +80909,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -80959,7 +80966,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -80969,7 +80976,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -81026,7 +81033,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -81036,7 +81043,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -81093,7 +81100,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -81103,7 +81110,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -81160,7 +81167,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -81170,7 +81177,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -81227,7 +81234,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -81237,7 +81244,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -81294,7 +81301,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -81304,7 +81311,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -81346,9 +81353,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00770--mixed4e-00779.jpg-->
-    
+
 
 
 
@@ -82133,7 +82140,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -82143,7 +82150,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -82200,7 +82207,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -82210,7 +82217,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -82267,7 +82274,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -82277,7 +82284,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -82334,7 +82341,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -82344,7 +82351,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -82401,7 +82408,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -82411,7 +82418,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -82468,7 +82475,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -82478,7 +82485,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -82535,7 +82542,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -82545,7 +82552,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -82602,7 +82609,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -82612,7 +82619,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -82669,7 +82676,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -82679,7 +82686,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -82736,7 +82743,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -82746,7 +82753,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -82788,9 +82795,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00780--mixed4e-00789.jpg-->
-    
+
 
 
 
@@ -83585,7 +83592,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -83595,7 +83602,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -83652,7 +83659,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -83662,7 +83669,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -83719,7 +83726,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -83729,7 +83736,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -83786,7 +83793,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -83796,7 +83803,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -83853,7 +83860,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -83863,7 +83870,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -83920,7 +83927,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -83930,7 +83937,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -83987,7 +83994,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -83997,7 +84004,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -84054,7 +84061,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -84064,7 +84071,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -84121,7 +84128,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -84131,7 +84138,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -84188,7 +84195,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -84198,7 +84205,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -84240,9 +84247,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00790--mixed4e-00799.jpg-->
-    
+
 
 
 
@@ -85047,7 +85054,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -85057,7 +85064,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -85114,7 +85121,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -85124,7 +85131,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -85181,7 +85188,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -85191,7 +85198,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -85248,7 +85255,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -85258,7 +85265,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -85315,7 +85322,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -85325,7 +85332,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -85382,7 +85389,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -85392,7 +85399,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -85449,7 +85456,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -85459,7 +85466,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -85516,7 +85523,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -85526,7 +85533,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -85583,7 +85590,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -85593,7 +85600,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -85650,7 +85657,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -85660,7 +85667,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -85702,9 +85709,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00800--mixed4e-00809.jpg-->
-    
+
 
 
 
@@ -86519,7 +86526,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -86529,7 +86536,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -86586,7 +86593,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -86596,7 +86603,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -86653,7 +86660,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -86663,7 +86670,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -86720,7 +86727,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -86730,7 +86737,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -86787,7 +86794,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -86797,7 +86804,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -86854,7 +86861,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -86864,7 +86871,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -86921,7 +86928,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -86931,7 +86938,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -86988,7 +86995,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -86998,7 +87005,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -87055,7 +87062,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -87065,7 +87072,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -87122,7 +87129,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -87132,7 +87139,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -87174,9 +87181,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00810--mixed4e-00819.jpg-->
-    
+
 
 
 
@@ -88001,7 +88008,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -88011,7 +88018,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -88068,7 +88075,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -88078,7 +88085,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -88135,7 +88142,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -88145,7 +88152,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -88202,7 +88209,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -88212,7 +88219,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -88269,7 +88276,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -88279,7 +88286,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -88336,7 +88343,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -88346,7 +88353,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -88403,7 +88410,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -88413,7 +88420,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -88470,7 +88477,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -88480,7 +88487,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -88537,7 +88544,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -88547,7 +88554,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -88604,7 +88611,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -88614,7 +88621,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -88656,9 +88663,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00820--mixed4e-00829.jpg-->
-    
+
 
 
 
@@ -89493,7 +89500,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -89503,7 +89510,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -89560,7 +89567,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -89570,7 +89577,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -89627,7 +89634,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -89637,7 +89644,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -89694,7 +89701,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -89704,7 +89711,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -89761,7 +89768,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -89771,7 +89778,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -89828,7 +89835,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -89838,7 +89845,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -89895,7 +89902,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -89905,7 +89912,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -89962,7 +89969,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -89972,7 +89979,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -90029,7 +90036,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -90039,7 +90046,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -90096,7 +90103,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -90106,7 +90113,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -90148,9 +90155,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed4e-00830--mixed4e-00831.jpg-->
-    
+
 
 
 
@@ -90995,7 +91002,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -91005,7 +91012,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -91062,7 +91069,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -91072,7 +91079,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -91114,9 +91121,8 @@
       </div>
       </d-figure>
       </li>
-  
+
   </ul>
   </d-article>
   <distill-footer></distill-footer>
 </body>
-  

--- a/public/appendix/googlenet/5a.html
+++ b/public/appendix/googlenet/5a.html
@@ -5,21 +5,21 @@
   <meta charset="utf8">
   <script src="https://distill.pub/template.v2.js"></script>
   <style>
-  
+
     d-article {
       line-height: 1em;
     }
-    
+
     d-byline,
     d-appendix {
       display: none;
     }
-  
+
     h4 {
       display: block;
       width: 100%;
     }
-    
+
     d-figure {
       display: flex;
       flex-flow: row;
@@ -31,7 +31,7 @@
       margin-bottom: 1em;
       justify-content: center;
     }
-    
+
     .positive,
     .negative {
       display: flex;
@@ -40,7 +40,7 @@
       align-content: flex-start;
       max-width: 370px;
     }
-    
+
     .positive {
       padding-left: 1em;
       padding-right: 1em;
@@ -50,14 +50,14 @@
       border-right: 1px solid rgba(0,0,0,0.1);
       justify-content: space-between;
     }
-    
+
     .figcaption {
       display: block;
       color: rgba(0, 0, 0, 0.6);
       font-size: 12px;
       line-height: 1.5em;
     }
-    
+
     .diversity {
       display: flex;
       flex-flow: row;
@@ -65,61 +65,61 @@
       width: 148px;
       height: 147px
     }
-    
+
     .diversity > div {
       zoom: 0.496598639;
     }
-    
+
     .channel {
       margin-right: 1em;
     }
-    
+
     .channels {
       grid-column: screen;
       list-style: none;
       padding-left: 0;
     }
-    
+
     .channels li {
       contain: content;
       overflow: hidden;
     }
-    
+
     .sprite {
       display: inline-block;
       margin: 1px;
       width: 147px;
       height: 147px;
     }
-    
+
     .sprite.neuron {
       background-position-x: 0px;
     }
-    
+
     .sprite.channel {
       background-position-x: -147px;
     }
-    
+
     .sprite.channel-negative {
       background-position-x: -294px;
     }
-    
+
     .sprite.channel-diversity-0 {
       background-position-x: -441px;
     }
-    
+
     .sprite.channel-diversity-1 {
       background-position-x: -588px;
     }
-    
+
     .sprite.channel-diversity-2 {
       background-position-x: -735px;
     }
-    
+
     .sprite.channel-diversity-3 {
       background-position-x: -882px;
     }
-    
+
     .dataset-examples {
       display: flex;
       flex-flow: row;
@@ -127,7 +127,7 @@
       width: 375px;
       height: 147px
     }
-    
+
     .dataset-examples .sprite {
       height: 73px;
       width: 73px;
@@ -136,16 +136,16 @@
       margin-bottom: 0;
       margin-right: 0;
     }
-    
-    
+
+
       .channels .sprite.dataset-index-0 {
         background-position-x: -1029px !important;
       }
-      
+
       .channels .sprite.index-0 {
         background-position-y: -0px;
       }
-      
+
       .channels .dataset-negative .sprite.index-0 {
         background-position-y: -74px !important;
       }
@@ -153,11 +153,11 @@
       .channels .sprite.dataset-index-1 {
         background-position-x: -1103px !important;
       }
-      
+
       .channels .sprite.index-1 {
         background-position-y: -147px;
       }
-      
+
       .channels .dataset-negative .sprite.index-1 {
         background-position-y: -221px !important;
       }
@@ -165,11 +165,11 @@
       .channels .sprite.dataset-index-2 {
         background-position-x: -1177px !important;
       }
-      
+
       .channels .sprite.index-2 {
         background-position-y: -294px;
       }
-      
+
       .channels .dataset-negative .sprite.index-2 {
         background-position-y: -368px !important;
       }
@@ -177,11 +177,11 @@
       .channels .sprite.dataset-index-3 {
         background-position-x: -1251px !important;
       }
-      
+
       .channels .sprite.index-3 {
         background-position-y: -441px;
       }
-      
+
       .channels .dataset-negative .sprite.index-3 {
         background-position-y: -515px !important;
       }
@@ -189,11 +189,11 @@
       .channels .sprite.dataset-index-4 {
         background-position-x: -1325px !important;
       }
-      
+
       .channels .sprite.index-4 {
         background-position-y: -588px;
       }
-      
+
       .channels .dataset-negative .sprite.index-4 {
         background-position-y: -662px !important;
       }
@@ -201,11 +201,11 @@
       .channels .sprite.dataset-index-5 {
         background-position-x: -1399px !important;
       }
-      
+
       .channels .sprite.index-5 {
         background-position-y: -735px;
       }
-      
+
       .channels .dataset-negative .sprite.index-5 {
         background-position-y: -809px !important;
       }
@@ -213,11 +213,11 @@
       .channels .sprite.dataset-index-6 {
         background-position-x: -1473px !important;
       }
-      
+
       .channels .sprite.index-6 {
         background-position-y: -882px;
       }
-      
+
       .channels .dataset-negative .sprite.index-6 {
         background-position-y: -956px !important;
       }
@@ -225,11 +225,11 @@
       .channels .sprite.dataset-index-7 {
         background-position-x: -1547px !important;
       }
-      
+
       .channels .sprite.index-7 {
         background-position-y: -1029px;
       }
-      
+
       .channels .dataset-negative .sprite.index-7 {
         background-position-y: -1103px !important;
       }
@@ -237,11 +237,11 @@
       .channels .sprite.dataset-index-8 {
         background-position-x: -1621px !important;
       }
-      
+
       .channels .sprite.index-8 {
         background-position-y: -1176px;
       }
-      
+
       .channels .dataset-negative .sprite.index-8 {
         background-position-y: -1250px !important;
       }
@@ -249,20 +249,20 @@
       .channels .sprite.dataset-index-9 {
         background-position-x: -1695px !important;
       }
-      
+
       .channels .sprite.index-9 {
         background-position-y: -1323px;
       }
-      
+
       .channels .dataset-negative .sprite.index-9 {
         background-position-y: -1397px !important;
       }
-    
-    
+
+
     .article-nav {
       grid-column: page;
     }
-    
+
     .navlist li {
       display: inline;
       list-style-type: none;
@@ -300,10 +300,10 @@
     <h1>Layer 5a</h1>
   </d-title>
   <d-article>
-  
+
   <nav class="article-nav">
-  
-    
+
+
     <ul class="navlist">
       <li><a href="https://distill.pub/2017/feature-visualization/appendix/">Appendix overview</a></li>
       <li><a href="https://distill.pub/2017/feature-visualization/">Main article</a></li>
@@ -331,20 +331,27 @@
         <a href="4e.html">Layer 4e</a>
       </li>
       <li>
-        <a href="5a.html">Layer 5a</a>
+        <a href="5a.html"><b>Layer 5a</b></a>
       </li>
       <li>
         <a href="5b.html">Layer 5b</a>
       </li>
     </ul>
-  
+
+    <ul class="navlist">
+      <li> <a href="5a.html#5a-0">5a 1x1</a> <span style="color: #777;">(0:256)</span> </li>
+      <li> <a href="5a.html#5a-256">5a 3x3</a> <span style="color: #777;">(256:576)</span> </li>
+      <li> <a href="5a.html#5a-576">5a 5x5</a> <span style="color: #777;">(576:704)</span> </li>
+      <li> <a href="5a.html#5a-704">5a pool</a> <span style="color: #777;">(704:832)</span> </li>
+    </ul>
+
   </nav>
-  
+
   <hr style="margin-top: 20px;"/>
-  
+
   <ul class="channels">
     <!--mixed5a-00000--mixed5a-00009.jpg-->
-    
+
       <li id="channel-0">
       <d-figure id="5a-0">
       <style data-img-src="images/mixed5a-00000--mixed5a-00009.jpg" data-channel="0"></style>
@@ -359,7 +366,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -369,7 +376,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -426,7 +433,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -436,7 +443,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -493,7 +500,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -503,7 +510,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -560,7 +567,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -570,7 +577,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -627,7 +634,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -637,7 +644,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -694,7 +701,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -704,7 +711,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -761,7 +768,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -771,7 +778,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -828,7 +835,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -838,7 +845,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -895,7 +902,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -905,7 +912,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -962,7 +969,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -972,7 +979,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -1014,9 +1021,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00010--mixed5a-00019.jpg-->
-    
+
 
 
 
@@ -1041,7 +1048,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -1051,7 +1058,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -1108,7 +1115,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -1118,7 +1125,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -1175,7 +1182,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -1185,7 +1192,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -1242,7 +1249,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -1252,7 +1259,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -1309,7 +1316,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -1319,7 +1326,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -1376,7 +1383,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -1386,7 +1393,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -1443,7 +1450,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -1453,7 +1460,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -1510,7 +1517,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -1520,7 +1527,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -1577,7 +1584,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -1587,7 +1594,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -1644,7 +1651,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -1654,7 +1661,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -1696,9 +1703,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00020--mixed5a-00029.jpg-->
-    
+
 
 
 
@@ -1733,7 +1740,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -1743,7 +1750,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -1800,7 +1807,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -1810,7 +1817,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -1867,7 +1874,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -1877,7 +1884,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -1934,7 +1941,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -1944,7 +1951,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -2001,7 +2008,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -2011,7 +2018,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -2068,7 +2075,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -2078,7 +2085,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -2135,7 +2142,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -2145,7 +2152,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -2202,7 +2209,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -2212,7 +2219,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -2269,7 +2276,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -2279,7 +2286,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -2336,7 +2343,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -2346,7 +2353,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -2388,9 +2395,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00030--mixed5a-00039.jpg-->
-    
+
 
 
 
@@ -2435,7 +2442,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -2445,7 +2452,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -2502,7 +2509,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -2512,7 +2519,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -2569,7 +2576,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -2579,7 +2586,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -2636,7 +2643,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -2646,7 +2653,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -2703,7 +2710,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -2713,7 +2720,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -2770,7 +2777,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -2780,7 +2787,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -2837,7 +2844,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -2847,7 +2854,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -2904,7 +2911,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -2914,7 +2921,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -2971,7 +2978,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -2981,7 +2988,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -3038,7 +3045,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -3048,7 +3055,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -3090,9 +3097,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00040--mixed5a-00049.jpg-->
-    
+
 
 
 
@@ -3147,7 +3154,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -3157,7 +3164,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -3214,7 +3221,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -3224,7 +3231,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -3281,7 +3288,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -3291,7 +3298,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -3348,7 +3355,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -3358,7 +3365,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -3415,7 +3422,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -3425,7 +3432,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -3482,7 +3489,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -3492,7 +3499,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -3549,7 +3556,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -3559,7 +3566,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -3616,7 +3623,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -3626,7 +3633,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -3683,7 +3690,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -3693,7 +3700,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -3750,7 +3757,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -3760,7 +3767,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -3802,9 +3809,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00050--mixed5a-00059.jpg-->
-    
+
 
 
 
@@ -3869,7 +3876,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -3879,7 +3886,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -3936,7 +3943,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -3946,7 +3953,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -4003,7 +4010,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -4013,7 +4020,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -4070,7 +4077,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -4080,7 +4087,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -4137,7 +4144,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -4147,7 +4154,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -4204,7 +4211,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -4214,7 +4221,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -4271,7 +4278,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -4281,7 +4288,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -4338,7 +4345,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -4348,7 +4355,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -4405,7 +4412,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -4415,7 +4422,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -4472,7 +4479,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -4482,7 +4489,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -4524,9 +4531,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00060--mixed5a-00069.jpg-->
-    
+
 
 
 
@@ -4601,7 +4608,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -4611,7 +4618,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -4668,7 +4675,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -4678,7 +4685,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -4735,7 +4742,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -4745,7 +4752,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -4802,7 +4809,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -4812,7 +4819,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -4869,7 +4876,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -4879,7 +4886,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -4936,7 +4943,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -4946,7 +4953,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -5003,7 +5010,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -5013,7 +5020,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -5070,7 +5077,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -5080,7 +5087,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -5137,7 +5144,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -5147,7 +5154,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -5204,7 +5211,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -5214,7 +5221,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -5256,9 +5263,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00070--mixed5a-00079.jpg-->
-    
+
 
 
 
@@ -5343,7 +5350,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -5353,7 +5360,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -5410,7 +5417,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -5420,7 +5427,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -5477,7 +5484,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -5487,7 +5494,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -5544,7 +5551,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -5554,7 +5561,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -5611,7 +5618,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -5621,7 +5628,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -5678,7 +5685,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -5688,7 +5695,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -5745,7 +5752,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -5755,7 +5762,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -5812,7 +5819,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -5822,7 +5829,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -5879,7 +5886,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -5889,7 +5896,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -5946,7 +5953,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -5956,7 +5963,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -5998,9 +6005,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00080--mixed5a-00089.jpg-->
-    
+
 
 
 
@@ -6095,7 +6102,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -6105,7 +6112,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -6162,7 +6169,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -6172,7 +6179,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -6229,7 +6236,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -6239,7 +6246,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -6296,7 +6303,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -6306,7 +6313,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -6363,7 +6370,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -6373,7 +6380,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -6430,7 +6437,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -6440,7 +6447,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -6497,7 +6504,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -6507,7 +6514,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -6564,7 +6571,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -6574,7 +6581,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -6631,7 +6638,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -6641,7 +6648,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -6698,7 +6705,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -6708,7 +6715,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -6750,9 +6757,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00090--mixed5a-00099.jpg-->
-    
+
 
 
 
@@ -6857,7 +6864,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -6867,7 +6874,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -6924,7 +6931,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -6934,7 +6941,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -6991,7 +6998,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -7001,7 +7008,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -7058,7 +7065,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -7068,7 +7075,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -7125,7 +7132,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -7135,7 +7142,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -7192,7 +7199,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -7202,7 +7209,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -7259,7 +7266,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -7269,7 +7276,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -7326,7 +7333,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -7336,7 +7343,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -7393,7 +7400,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -7403,7 +7410,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -7460,7 +7467,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -7470,7 +7477,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -7512,9 +7519,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00100--mixed5a-00109.jpg-->
-    
+
 
 
 
@@ -7629,7 +7636,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -7639,7 +7646,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -7696,7 +7703,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -7706,7 +7713,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -7763,7 +7770,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -7773,7 +7780,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -7830,7 +7837,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -7840,7 +7847,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -7897,7 +7904,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -7907,7 +7914,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -7964,7 +7971,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -7974,7 +7981,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -8031,7 +8038,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -8041,7 +8048,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -8098,7 +8105,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -8108,7 +8115,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -8165,7 +8172,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -8175,7 +8182,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -8232,7 +8239,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -8242,7 +8249,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -8284,9 +8291,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00110--mixed5a-00119.jpg-->
-    
+
 
 
 
@@ -8411,7 +8418,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -8421,7 +8428,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -8478,7 +8485,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -8488,7 +8495,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -8545,7 +8552,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -8555,7 +8562,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -8612,7 +8619,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -8622,7 +8629,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -8679,7 +8686,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -8689,7 +8696,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -8746,7 +8753,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -8756,7 +8763,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -8813,7 +8820,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -8823,7 +8830,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -8880,7 +8887,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -8890,7 +8897,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -8947,7 +8954,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -8957,7 +8964,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -9014,7 +9021,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -9024,7 +9031,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -9066,9 +9073,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00120--mixed5a-00129.jpg-->
-    
+
 
 
 
@@ -9203,7 +9210,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -9213,7 +9220,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -9270,7 +9277,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -9280,7 +9287,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -9337,7 +9344,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -9347,7 +9354,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -9404,7 +9411,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -9414,7 +9421,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -9471,7 +9478,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -9481,7 +9488,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -9538,7 +9545,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -9548,7 +9555,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -9605,7 +9612,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -9615,7 +9622,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -9672,7 +9679,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -9682,7 +9689,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -9739,7 +9746,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -9749,7 +9756,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -9806,7 +9813,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -9816,7 +9823,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -9858,9 +9865,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00130--mixed5a-00139.jpg-->
-    
+
 
 
 
@@ -10005,7 +10012,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -10015,7 +10022,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -10072,7 +10079,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -10082,7 +10089,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -10139,7 +10146,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -10149,7 +10156,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -10206,7 +10213,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -10216,7 +10223,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -10273,7 +10280,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -10283,7 +10290,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -10340,7 +10347,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -10350,7 +10357,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -10407,7 +10414,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -10417,7 +10424,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -10474,7 +10481,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -10484,7 +10491,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -10541,7 +10548,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -10551,7 +10558,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -10608,7 +10615,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -10618,7 +10625,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -10660,9 +10667,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00140--mixed5a-00149.jpg-->
-    
+
 
 
 
@@ -10817,7 +10824,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -10827,7 +10834,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -10884,7 +10891,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -10894,7 +10901,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -10951,7 +10958,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -10961,7 +10968,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -11018,7 +11025,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -11028,7 +11035,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -11085,7 +11092,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -11095,7 +11102,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -11152,7 +11159,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -11162,7 +11169,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -11219,7 +11226,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -11229,7 +11236,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -11286,7 +11293,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -11296,7 +11303,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -11353,7 +11360,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -11363,7 +11370,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -11420,7 +11427,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -11430,7 +11437,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -11472,9 +11479,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00150--mixed5a-00159.jpg-->
-    
+
 
 
 
@@ -11639,7 +11646,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -11649,7 +11656,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -11706,7 +11713,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -11716,7 +11723,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -11773,7 +11780,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -11783,7 +11790,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -11840,7 +11847,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -11850,7 +11857,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -11907,7 +11914,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -11917,7 +11924,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -11974,7 +11981,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -11984,7 +11991,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -12041,7 +12048,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -12051,7 +12058,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -12108,7 +12115,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -12118,7 +12125,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -12175,7 +12182,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -12185,7 +12192,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -12242,7 +12249,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -12252,7 +12259,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -12294,9 +12301,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00160--mixed5a-00169.jpg-->
-    
+
 
 
 
@@ -12471,7 +12478,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -12481,7 +12488,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -12538,7 +12545,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -12548,7 +12555,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -12605,7 +12612,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -12615,7 +12622,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -12672,7 +12679,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -12682,7 +12689,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -12739,7 +12746,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -12749,7 +12756,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -12806,7 +12813,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -12816,7 +12823,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -12873,7 +12880,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -12883,7 +12890,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -12940,7 +12947,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -12950,7 +12957,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -13007,7 +13014,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -13017,7 +13024,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -13074,7 +13081,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -13084,7 +13091,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -13126,9 +13133,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00170--mixed5a-00179.jpg-->
-    
+
 
 
 
@@ -13313,7 +13320,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -13323,7 +13330,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -13380,7 +13387,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -13390,7 +13397,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -13447,7 +13454,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -13457,7 +13464,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -13514,7 +13521,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -13524,7 +13531,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -13581,7 +13588,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -13591,7 +13598,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -13648,7 +13655,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -13658,7 +13665,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -13715,7 +13722,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -13725,7 +13732,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -13782,7 +13789,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -13792,7 +13799,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -13849,7 +13856,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -13859,7 +13866,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -13916,7 +13923,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -13926,7 +13933,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -13968,9 +13975,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00180--mixed5a-00189.jpg-->
-    
+
 
 
 
@@ -14165,7 +14172,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -14175,7 +14182,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -14232,7 +14239,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -14242,7 +14249,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -14299,7 +14306,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -14309,7 +14316,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -14366,7 +14373,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -14376,7 +14383,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -14433,7 +14440,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -14443,7 +14450,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -14500,7 +14507,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -14510,7 +14517,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -14567,7 +14574,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -14577,7 +14584,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -14634,7 +14641,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -14644,7 +14651,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -14701,7 +14708,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -14711,7 +14718,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -14768,7 +14775,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -14778,7 +14785,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -14820,9 +14827,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00190--mixed5a-00199.jpg-->
-    
+
 
 
 
@@ -15027,7 +15034,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -15037,7 +15044,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -15094,7 +15101,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -15104,7 +15111,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -15161,7 +15168,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -15171,7 +15178,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -15228,7 +15235,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -15238,7 +15245,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -15295,7 +15302,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -15305,7 +15312,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -15362,7 +15369,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -15372,7 +15379,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -15429,7 +15436,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -15439,7 +15446,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -15496,7 +15503,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -15506,7 +15513,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -15563,7 +15570,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -15573,7 +15580,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -15630,7 +15637,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -15640,7 +15647,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -15682,9 +15689,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00200--mixed5a-00209.jpg-->
-    
+
 
 
 
@@ -15899,7 +15906,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -15909,7 +15916,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -15966,7 +15973,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -15976,7 +15983,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -16033,7 +16040,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -16043,7 +16050,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -16100,7 +16107,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -16110,7 +16117,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -16167,7 +16174,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -16177,7 +16184,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -16234,7 +16241,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -16244,7 +16251,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -16301,7 +16308,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -16311,7 +16318,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -16368,7 +16375,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -16378,7 +16385,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -16435,7 +16442,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -16445,7 +16452,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -16502,7 +16509,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -16512,7 +16519,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -16554,9 +16561,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00210--mixed5a-00219.jpg-->
-    
+
 
 
 
@@ -16781,7 +16788,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -16791,7 +16798,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -16848,7 +16855,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -16858,7 +16865,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -16915,7 +16922,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -16925,7 +16932,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -16982,7 +16989,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -16992,7 +16999,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -17049,7 +17056,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -17059,7 +17066,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -17116,7 +17123,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -17126,7 +17133,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -17183,7 +17190,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -17193,7 +17200,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -17250,7 +17257,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -17260,7 +17267,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -17317,7 +17324,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -17327,7 +17334,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -17384,7 +17391,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -17394,7 +17401,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -17436,9 +17443,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00220--mixed5a-00229.jpg-->
-    
+
 
 
 
@@ -17673,7 +17680,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -17683,7 +17690,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -17740,7 +17747,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -17750,7 +17757,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -17807,7 +17814,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -17817,7 +17824,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -17874,7 +17881,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -17884,7 +17891,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -17941,7 +17948,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -17951,7 +17958,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -18008,7 +18015,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -18018,7 +18025,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -18075,7 +18082,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -18085,7 +18092,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -18142,7 +18149,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -18152,7 +18159,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -18209,7 +18216,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -18219,7 +18226,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -18276,7 +18283,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -18286,7 +18293,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -18328,9 +18335,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00230--mixed5a-00239.jpg-->
-    
+
 
 
 
@@ -18575,7 +18582,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -18585,7 +18592,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -18642,7 +18649,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -18652,7 +18659,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -18709,7 +18716,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -18719,7 +18726,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -18776,7 +18783,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -18786,7 +18793,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -18843,7 +18850,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -18853,7 +18860,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -18910,7 +18917,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -18920,7 +18927,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -18977,7 +18984,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -18987,7 +18994,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -19044,7 +19051,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -19054,7 +19061,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -19111,7 +19118,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -19121,7 +19128,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -19178,7 +19185,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -19188,7 +19195,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -19230,9 +19237,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00240--mixed5a-00249.jpg-->
-    
+
 
 
 
@@ -19487,7 +19494,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -19497,7 +19504,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -19554,7 +19561,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -19564,7 +19571,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -19621,7 +19628,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -19631,7 +19638,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -19688,7 +19695,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -19698,7 +19705,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -19755,7 +19762,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -19765,7 +19772,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -19822,7 +19829,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -19832,7 +19839,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -19889,7 +19896,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -19899,7 +19906,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -19956,7 +19963,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -19966,7 +19973,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -20023,7 +20030,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -20033,7 +20040,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -20090,7 +20097,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -20100,7 +20107,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -20142,9 +20149,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00250--mixed5a-00259.jpg-->
-    
+
 
 
 
@@ -20409,7 +20416,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -20419,7 +20426,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -20476,7 +20483,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -20486,7 +20493,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -20543,7 +20550,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -20553,7 +20560,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -20610,7 +20617,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -20620,7 +20627,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -20677,7 +20684,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -20687,7 +20694,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -20744,7 +20751,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -20754,7 +20761,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -20811,7 +20818,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -20821,7 +20828,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -20878,7 +20885,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -20888,7 +20895,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -20945,7 +20952,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -20955,7 +20962,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -21012,7 +21019,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -21022,7 +21029,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -21064,9 +21071,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00260--mixed5a-00269.jpg-->
-    
+
 
 
 
@@ -21341,7 +21348,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -21351,7 +21358,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -21408,7 +21415,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -21418,7 +21425,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -21475,7 +21482,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -21485,7 +21492,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -21542,7 +21549,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -21552,7 +21559,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -21609,7 +21616,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -21619,7 +21626,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -21676,7 +21683,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -21686,7 +21693,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -21743,7 +21750,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -21753,7 +21760,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -21810,7 +21817,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -21820,7 +21827,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -21877,7 +21884,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -21887,7 +21894,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -21944,7 +21951,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -21954,7 +21961,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -21996,9 +22003,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00270--mixed5a-00279.jpg-->
-    
+
 
 
 
@@ -22283,7 +22290,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -22293,7 +22300,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -22350,7 +22357,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -22360,7 +22367,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -22417,7 +22424,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -22427,7 +22434,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -22484,7 +22491,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -22494,7 +22501,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -22551,7 +22558,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -22561,7 +22568,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -22618,7 +22625,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -22628,7 +22635,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -22685,7 +22692,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -22695,7 +22702,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -22752,7 +22759,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -22762,7 +22769,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -22819,7 +22826,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -22829,7 +22836,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -22886,7 +22893,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -22896,7 +22903,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -22938,9 +22945,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00280--mixed5a-00289.jpg-->
-    
+
 
 
 
@@ -23235,7 +23242,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -23245,7 +23252,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -23302,7 +23309,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -23312,7 +23319,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -23369,7 +23376,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -23379,7 +23386,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -23436,7 +23443,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -23446,7 +23453,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -23503,7 +23510,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -23513,7 +23520,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -23570,7 +23577,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -23580,7 +23587,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -23637,7 +23644,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -23647,7 +23654,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -23704,7 +23711,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -23714,7 +23721,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -23771,7 +23778,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -23781,7 +23788,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -23838,7 +23845,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -23848,7 +23855,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -23890,9 +23897,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00290--mixed5a-00299.jpg-->
-    
+
 
 
 
@@ -24197,7 +24204,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -24207,7 +24214,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -24264,7 +24271,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -24274,7 +24281,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -24331,7 +24338,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -24341,7 +24348,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -24398,7 +24405,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -24408,7 +24415,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -24465,7 +24472,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -24475,7 +24482,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -24532,7 +24539,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -24542,7 +24549,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -24599,7 +24606,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -24609,7 +24616,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -24666,7 +24673,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -24676,7 +24683,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -24733,7 +24740,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -24743,7 +24750,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -24800,7 +24807,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -24810,7 +24817,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -24852,9 +24859,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00300--mixed5a-00309.jpg-->
-    
+
 
 
 
@@ -25169,7 +25176,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -25179,7 +25186,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -25236,7 +25243,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -25246,7 +25253,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -25303,7 +25310,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -25313,7 +25320,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -25370,7 +25377,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -25380,7 +25387,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -25437,7 +25444,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -25447,7 +25454,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -25504,7 +25511,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -25514,7 +25521,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -25571,7 +25578,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -25581,7 +25588,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -25638,7 +25645,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -25648,7 +25655,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -25705,7 +25712,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -25715,7 +25722,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -25772,7 +25779,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -25782,7 +25789,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -25824,9 +25831,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00310--mixed5a-00319.jpg-->
-    
+
 
 
 
@@ -26151,7 +26158,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -26161,7 +26168,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -26218,7 +26225,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -26228,7 +26235,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -26285,7 +26292,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -26295,7 +26302,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -26352,7 +26359,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -26362,7 +26369,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -26419,7 +26426,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -26429,7 +26436,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -26486,7 +26493,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -26496,7 +26503,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -26553,7 +26560,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -26563,7 +26570,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -26620,7 +26627,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -26630,7 +26637,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -26687,7 +26694,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -26697,7 +26704,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -26754,7 +26761,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -26764,7 +26771,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -26806,9 +26813,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00320--mixed5a-00329.jpg-->
-    
+
 
 
 
@@ -27143,7 +27150,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -27153,7 +27160,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -27210,7 +27217,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -27220,7 +27227,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -27277,7 +27284,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -27287,7 +27294,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -27344,7 +27351,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -27354,7 +27361,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -27411,7 +27418,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -27421,7 +27428,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -27478,7 +27485,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -27488,7 +27495,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -27545,7 +27552,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -27555,7 +27562,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -27612,7 +27619,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -27622,7 +27629,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -27679,7 +27686,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -27689,7 +27696,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -27746,7 +27753,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -27756,7 +27763,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -27798,9 +27805,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00330--mixed5a-00339.jpg-->
-    
+
 
 
 
@@ -28145,7 +28152,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -28155,7 +28162,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -28212,7 +28219,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -28222,7 +28229,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -28279,7 +28286,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -28289,7 +28296,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -28346,7 +28353,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -28356,7 +28363,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -28413,7 +28420,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -28423,7 +28430,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -28480,7 +28487,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -28490,7 +28497,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -28547,7 +28554,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -28557,7 +28564,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -28614,7 +28621,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -28624,7 +28631,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -28681,7 +28688,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -28691,7 +28698,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -28748,7 +28755,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -28758,7 +28765,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -28800,9 +28807,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00340--mixed5a-00349.jpg-->
-    
+
 
 
 
@@ -29157,7 +29164,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -29167,7 +29174,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -29224,7 +29231,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -29234,7 +29241,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -29291,7 +29298,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -29301,7 +29308,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -29358,7 +29365,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -29368,7 +29375,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -29425,7 +29432,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -29435,7 +29442,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -29492,7 +29499,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -29502,7 +29509,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -29559,7 +29566,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -29569,7 +29576,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -29626,7 +29633,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -29636,7 +29643,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -29693,7 +29700,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -29703,7 +29710,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -29760,7 +29767,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -29770,7 +29777,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -29812,9 +29819,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00350--mixed5a-00359.jpg-->
-    
+
 
 
 
@@ -30179,7 +30186,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -30189,7 +30196,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -30246,7 +30253,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -30256,7 +30263,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -30313,7 +30320,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -30323,7 +30330,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -30380,7 +30387,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -30390,7 +30397,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -30447,7 +30454,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -30457,7 +30464,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -30514,7 +30521,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -30524,7 +30531,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -30581,7 +30588,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -30591,7 +30598,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -30648,7 +30655,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -30658,7 +30665,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -30715,7 +30722,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -30725,7 +30732,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -30782,7 +30789,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -30792,7 +30799,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -30834,9 +30841,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00360--mixed5a-00369.jpg-->
-    
+
 
 
 
@@ -31211,7 +31218,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -31221,7 +31228,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -31278,7 +31285,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -31288,7 +31295,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -31345,7 +31352,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -31355,7 +31362,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -31412,7 +31419,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -31422,7 +31429,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -31479,7 +31486,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -31489,7 +31496,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -31546,7 +31553,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -31556,7 +31563,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -31613,7 +31620,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -31623,7 +31630,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -31680,7 +31687,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -31690,7 +31697,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -31747,7 +31754,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -31757,7 +31764,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -31814,7 +31821,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -31824,7 +31831,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -31866,9 +31873,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00370--mixed5a-00379.jpg-->
-    
+
 
 
 
@@ -32253,7 +32260,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -32263,7 +32270,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -32320,7 +32327,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -32330,7 +32337,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -32387,7 +32394,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -32397,7 +32404,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -32454,7 +32461,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -32464,7 +32471,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -32521,7 +32528,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -32531,7 +32538,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -32588,7 +32595,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -32598,7 +32605,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -32655,7 +32662,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -32665,7 +32672,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -32722,7 +32729,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -32732,7 +32739,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -32789,7 +32796,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -32799,7 +32806,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -32856,7 +32863,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -32866,7 +32873,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -32908,9 +32915,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00380--mixed5a-00389.jpg-->
-    
+
 
 
 
@@ -33305,7 +33312,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -33315,7 +33322,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -33372,7 +33379,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -33382,7 +33389,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -33439,7 +33446,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -33449,7 +33456,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -33506,7 +33513,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -33516,7 +33523,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -33573,7 +33580,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -33583,7 +33590,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -33640,7 +33647,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -33650,7 +33657,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -33707,7 +33714,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -33717,7 +33724,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -33774,7 +33781,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -33784,7 +33791,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -33841,7 +33848,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -33851,7 +33858,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -33908,7 +33915,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -33918,7 +33925,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -33960,9 +33967,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00390--mixed5a-00399.jpg-->
-    
+
 
 
 
@@ -34367,7 +34374,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -34377,7 +34384,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -34434,7 +34441,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -34444,7 +34451,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -34501,7 +34508,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -34511,7 +34518,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -34568,7 +34575,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -34578,7 +34585,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -34635,7 +34642,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -34645,7 +34652,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -34702,7 +34709,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -34712,7 +34719,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -34769,7 +34776,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -34779,7 +34786,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -34836,7 +34843,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -34846,7 +34853,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -34903,7 +34910,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -34913,7 +34920,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -34970,7 +34977,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -34980,7 +34987,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -35022,9 +35029,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00400--mixed5a-00409.jpg-->
-    
+
 
 
 
@@ -35439,7 +35446,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -35449,7 +35456,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -35506,7 +35513,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -35516,7 +35523,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -35573,7 +35580,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -35583,7 +35590,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -35640,7 +35647,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -35650,7 +35657,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -35707,7 +35714,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -35717,7 +35724,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -35774,7 +35781,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -35784,7 +35791,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -35841,7 +35848,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -35851,7 +35858,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -35908,7 +35915,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -35918,7 +35925,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -35975,7 +35982,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -35985,7 +35992,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -36042,7 +36049,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -36052,7 +36059,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -36094,9 +36101,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00410--mixed5a-00419.jpg-->
-    
+
 
 
 
@@ -36521,7 +36528,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -36531,7 +36538,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -36588,7 +36595,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -36598,7 +36605,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -36655,7 +36662,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -36665,7 +36672,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -36722,7 +36729,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -36732,7 +36739,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -36789,7 +36796,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -36799,7 +36806,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -36856,7 +36863,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -36866,7 +36873,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -36923,7 +36930,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -36933,7 +36940,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -36990,7 +36997,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -37000,7 +37007,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -37057,7 +37064,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -37067,7 +37074,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -37124,7 +37131,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -37134,7 +37141,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -37176,9 +37183,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00420--mixed5a-00429.jpg-->
-    
+
 
 
 
@@ -37613,7 +37620,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -37623,7 +37630,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -37680,7 +37687,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -37690,7 +37697,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -37747,7 +37754,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -37757,7 +37764,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -37814,7 +37821,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -37824,7 +37831,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -37881,7 +37888,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -37891,7 +37898,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -37948,7 +37955,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -37958,7 +37965,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -38015,7 +38022,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -38025,7 +38032,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -38082,7 +38089,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -38092,7 +38099,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -38149,7 +38156,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -38159,7 +38166,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -38216,7 +38223,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -38226,7 +38233,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -38268,9 +38275,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00430--mixed5a-00439.jpg-->
-    
+
 
 
 
@@ -38715,7 +38722,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -38725,7 +38732,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -38782,7 +38789,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -38792,7 +38799,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -38849,7 +38856,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -38859,7 +38866,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -38916,7 +38923,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -38926,7 +38933,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -38983,7 +38990,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -38993,7 +39000,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -39050,7 +39057,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -39060,7 +39067,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -39117,7 +39124,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -39127,7 +39134,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -39184,7 +39191,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -39194,7 +39201,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -39251,7 +39258,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -39261,7 +39268,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -39318,7 +39325,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -39328,7 +39335,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -39370,9 +39377,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00440--mixed5a-00449.jpg-->
-    
+
 
 
 
@@ -39827,7 +39834,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -39837,7 +39844,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -39894,7 +39901,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -39904,7 +39911,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -39961,7 +39968,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -39971,7 +39978,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -40028,7 +40035,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -40038,7 +40045,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -40095,7 +40102,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -40105,7 +40112,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -40162,7 +40169,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -40172,7 +40179,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -40229,7 +40236,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -40239,7 +40246,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -40296,7 +40303,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -40306,7 +40313,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -40363,7 +40370,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -40373,7 +40380,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -40430,7 +40437,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -40440,7 +40447,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -40482,9 +40489,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00450--mixed5a-00459.jpg-->
-    
+
 
 
 
@@ -40949,7 +40956,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -40959,7 +40966,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -41016,7 +41023,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -41026,7 +41033,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -41083,7 +41090,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -41093,7 +41100,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -41150,7 +41157,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -41160,7 +41167,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -41217,7 +41224,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -41227,7 +41234,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -41284,7 +41291,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -41294,7 +41301,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -41351,7 +41358,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -41361,7 +41368,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -41418,7 +41425,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -41428,7 +41435,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -41485,7 +41492,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -41495,7 +41502,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -41552,7 +41559,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -41562,7 +41569,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -41604,9 +41611,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00460--mixed5a-00469.jpg-->
-    
+
 
 
 
@@ -42081,7 +42088,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -42091,7 +42098,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -42148,7 +42155,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -42158,7 +42165,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -42215,7 +42222,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -42225,7 +42232,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -42282,7 +42289,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -42292,7 +42299,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -42349,7 +42356,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -42359,7 +42366,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -42416,7 +42423,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -42426,7 +42433,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -42483,7 +42490,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -42493,7 +42500,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -42550,7 +42557,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -42560,7 +42567,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -42617,7 +42624,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -42627,7 +42634,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -42684,7 +42691,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -42694,7 +42701,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -42736,9 +42743,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00470--mixed5a-00479.jpg-->
-    
+
 
 
 
@@ -43223,7 +43230,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -43233,7 +43240,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -43290,7 +43297,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -43300,7 +43307,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -43357,7 +43364,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -43367,7 +43374,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -43424,7 +43431,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -43434,7 +43441,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -43491,7 +43498,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -43501,7 +43508,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -43558,7 +43565,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -43568,7 +43575,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -43625,7 +43632,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -43635,7 +43642,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -43692,7 +43699,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -43702,7 +43709,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -43759,7 +43766,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -43769,7 +43776,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -43826,7 +43833,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -43836,7 +43843,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -43878,9 +43885,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00480--mixed5a-00489.jpg-->
-    
+
 
 
 
@@ -44375,7 +44382,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -44385,7 +44392,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -44442,7 +44449,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -44452,7 +44459,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -44509,7 +44516,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -44519,7 +44526,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -44576,7 +44583,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -44586,7 +44593,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -44643,7 +44650,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -44653,7 +44660,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -44710,7 +44717,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -44720,7 +44727,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -44777,7 +44784,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -44787,7 +44794,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -44844,7 +44851,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -44854,7 +44861,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -44911,7 +44918,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -44921,7 +44928,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -44978,7 +44985,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -44988,7 +44995,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -45030,9 +45037,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00490--mixed5a-00499.jpg-->
-    
+
 
 
 
@@ -45537,7 +45544,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -45547,7 +45554,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -45604,7 +45611,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -45614,7 +45621,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -45671,7 +45678,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -45681,7 +45688,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -45738,7 +45745,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -45748,7 +45755,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -45805,7 +45812,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -45815,7 +45822,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -45872,7 +45879,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -45882,7 +45889,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -45939,7 +45946,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -45949,7 +45956,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -46006,7 +46013,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -46016,7 +46023,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -46073,7 +46080,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -46083,7 +46090,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -46140,7 +46147,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -46150,7 +46157,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -46192,9 +46199,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00500--mixed5a-00509.jpg-->
-    
+
 
 
 
@@ -46709,7 +46716,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -46719,7 +46726,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -46776,7 +46783,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -46786,7 +46793,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -46843,7 +46850,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -46853,7 +46860,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -46910,7 +46917,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -46920,7 +46927,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -46977,7 +46984,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -46987,7 +46994,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -47044,7 +47051,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -47054,7 +47061,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -47111,7 +47118,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -47121,7 +47128,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -47178,7 +47185,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -47188,7 +47195,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -47245,7 +47252,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -47255,7 +47262,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -47312,7 +47319,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -47322,7 +47329,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -47364,9 +47371,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00510--mixed5a-00519.jpg-->
-    
+
 
 
 
@@ -47891,7 +47898,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -47901,7 +47908,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -47958,7 +47965,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -47968,7 +47975,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -48025,7 +48032,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -48035,7 +48042,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -48092,7 +48099,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -48102,7 +48109,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -48159,7 +48166,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -48169,7 +48176,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -48226,7 +48233,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -48236,7 +48243,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -48293,7 +48300,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -48303,7 +48310,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -48360,7 +48367,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -48370,7 +48377,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -48427,7 +48434,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -48437,7 +48444,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -48494,7 +48501,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -48504,7 +48511,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -48546,9 +48553,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00520--mixed5a-00529.jpg-->
-    
+
 
 
 
@@ -49083,7 +49090,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -49093,7 +49100,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -49150,7 +49157,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -49160,7 +49167,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -49217,7 +49224,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -49227,7 +49234,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -49284,7 +49291,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -49294,7 +49301,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -49351,7 +49358,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -49361,7 +49368,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -49418,7 +49425,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -49428,7 +49435,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -49485,7 +49492,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -49495,7 +49502,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -49552,7 +49559,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -49562,7 +49569,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -49619,7 +49626,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -49629,7 +49636,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -49686,7 +49693,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -49696,7 +49703,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -49738,9 +49745,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00530--mixed5a-00539.jpg-->
-    
+
 
 
 
@@ -50285,7 +50292,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -50295,7 +50302,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -50352,7 +50359,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -50362,7 +50369,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -50419,7 +50426,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -50429,7 +50436,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -50486,7 +50493,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -50496,7 +50503,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -50553,7 +50560,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -50563,7 +50570,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -50620,7 +50627,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -50630,7 +50637,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -50687,7 +50694,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -50697,7 +50704,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -50754,7 +50761,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -50764,7 +50771,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -50821,7 +50828,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -50831,7 +50838,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -50888,7 +50895,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -50898,7 +50905,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -50940,9 +50947,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00540--mixed5a-00549.jpg-->
-    
+
 
 
 
@@ -51497,7 +51504,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -51507,7 +51514,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -51564,7 +51571,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -51574,7 +51581,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -51631,7 +51638,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -51641,7 +51648,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -51698,7 +51705,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -51708,7 +51715,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -51765,7 +51772,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -51775,7 +51782,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -51832,7 +51839,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -51842,7 +51849,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -51899,7 +51906,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -51909,7 +51916,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -51966,7 +51973,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -51976,7 +51983,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -52033,7 +52040,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -52043,7 +52050,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -52100,7 +52107,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -52110,7 +52117,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -52152,9 +52159,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00550--mixed5a-00559.jpg-->
-    
+
 
 
 
@@ -52719,7 +52726,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -52729,7 +52736,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -52786,7 +52793,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -52796,7 +52803,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -52853,7 +52860,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -52863,7 +52870,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -52920,7 +52927,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -52930,7 +52937,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -52987,7 +52994,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -52997,7 +53004,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -53054,7 +53061,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -53064,7 +53071,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -53121,7 +53128,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -53131,7 +53138,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -53188,7 +53195,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -53198,7 +53205,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -53255,7 +53262,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -53265,7 +53272,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -53322,7 +53329,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -53332,7 +53339,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -53374,9 +53381,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00560--mixed5a-00569.jpg-->
-    
+
 
 
 
@@ -53951,7 +53958,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -53961,7 +53968,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -54018,7 +54025,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -54028,7 +54035,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -54085,7 +54092,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -54095,7 +54102,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -54152,7 +54159,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -54162,7 +54169,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -54219,7 +54226,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -54229,7 +54236,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -54286,7 +54293,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -54296,7 +54303,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -54353,7 +54360,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -54363,7 +54370,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -54420,7 +54427,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -54430,7 +54437,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -54487,7 +54494,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -54497,7 +54504,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -54554,7 +54561,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -54564,7 +54571,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -54606,9 +54613,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00570--mixed5a-00579.jpg-->
-    
+
 
 
 
@@ -55193,7 +55200,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -55203,7 +55210,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -55260,7 +55267,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -55270,7 +55277,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -55327,7 +55334,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -55337,7 +55344,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -55394,7 +55401,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -55404,7 +55411,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -55461,7 +55468,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -55471,7 +55478,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -55528,7 +55535,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -55538,7 +55545,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -55595,7 +55602,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -55605,7 +55612,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -55662,7 +55669,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -55672,7 +55679,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -55729,7 +55736,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -55739,7 +55746,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -55796,7 +55803,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -55806,7 +55813,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -55848,9 +55855,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00580--mixed5a-00589.jpg-->
-    
+
 
 
 
@@ -56445,7 +56452,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -56455,7 +56462,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -56512,7 +56519,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -56522,7 +56529,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -56579,7 +56586,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -56589,7 +56596,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -56646,7 +56653,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -56656,7 +56663,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -56713,7 +56720,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -56723,7 +56730,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -56780,7 +56787,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -56790,7 +56797,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -56847,7 +56854,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -56857,7 +56864,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -56914,7 +56921,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -56924,7 +56931,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -56981,7 +56988,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -56991,7 +56998,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -57048,7 +57055,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -57058,7 +57065,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -57100,9 +57107,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00590--mixed5a-00599.jpg-->
-    
+
 
 
 
@@ -57707,7 +57714,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -57717,7 +57724,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -57774,7 +57781,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -57784,7 +57791,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -57841,7 +57848,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -57851,7 +57858,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -57908,7 +57915,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -57918,7 +57925,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -57975,7 +57982,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -57985,7 +57992,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -58042,7 +58049,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -58052,7 +58059,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -58109,7 +58116,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -58119,7 +58126,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -58176,7 +58183,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -58186,7 +58193,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -58243,7 +58250,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -58253,7 +58260,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -58310,7 +58317,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -58320,7 +58327,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -58362,9 +58369,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00600--mixed5a-00609.jpg-->
-    
+
 
 
 
@@ -58979,7 +58986,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -58989,7 +58996,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -59046,7 +59053,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -59056,7 +59063,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -59113,7 +59120,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -59123,7 +59130,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -59180,7 +59187,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -59190,7 +59197,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -59247,7 +59254,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -59257,7 +59264,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -59314,7 +59321,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -59324,7 +59331,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -59381,7 +59388,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -59391,7 +59398,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -59448,7 +59455,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -59458,7 +59465,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -59515,7 +59522,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -59525,7 +59532,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -59582,7 +59589,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -59592,7 +59599,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -59634,9 +59641,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00610--mixed5a-00619.jpg-->
-    
+
 
 
 
@@ -60261,7 +60268,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -60271,7 +60278,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -60328,7 +60335,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -60338,7 +60345,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -60395,7 +60402,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -60405,7 +60412,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -60462,7 +60469,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -60472,7 +60479,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -60529,7 +60536,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -60539,7 +60546,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -60596,7 +60603,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -60606,7 +60613,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -60663,7 +60670,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -60673,7 +60680,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -60730,7 +60737,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -60740,7 +60747,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -60797,7 +60804,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -60807,7 +60814,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -60864,7 +60871,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -60874,7 +60881,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -60916,9 +60923,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00620--mixed5a-00629.jpg-->
-    
+
 
 
 
@@ -61553,7 +61560,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -61563,7 +61570,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -61620,7 +61627,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -61630,7 +61637,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -61687,7 +61694,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -61697,7 +61704,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -61754,7 +61761,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -61764,7 +61771,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -61821,7 +61828,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -61831,7 +61838,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -61888,7 +61895,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -61898,7 +61905,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -61955,7 +61962,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -61965,7 +61972,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -62022,7 +62029,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -62032,7 +62039,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -62089,7 +62096,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -62099,7 +62106,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -62156,7 +62163,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -62166,7 +62173,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -62208,9 +62215,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00630--mixed5a-00639.jpg-->
-    
+
 
 
 
@@ -62855,7 +62862,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -62865,7 +62872,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -62922,7 +62929,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -62932,7 +62939,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -62989,7 +62996,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -62999,7 +63006,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -63056,7 +63063,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -63066,7 +63073,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -63123,7 +63130,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -63133,7 +63140,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -63190,7 +63197,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -63200,7 +63207,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -63257,7 +63264,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -63267,7 +63274,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -63324,7 +63331,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -63334,7 +63341,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -63391,7 +63398,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -63401,7 +63408,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -63458,7 +63465,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -63468,7 +63475,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -63510,9 +63517,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00640--mixed5a-00649.jpg-->
-    
+
 
 
 
@@ -64167,7 +64174,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -64177,7 +64184,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -64234,7 +64241,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -64244,7 +64251,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -64301,7 +64308,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -64311,7 +64318,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -64368,7 +64375,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -64378,7 +64385,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -64435,7 +64442,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -64445,7 +64452,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -64502,7 +64509,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -64512,7 +64519,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -64569,7 +64576,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -64579,7 +64586,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -64636,7 +64643,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -64646,7 +64653,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -64703,7 +64710,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -64713,7 +64720,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -64770,7 +64777,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -64780,7 +64787,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -64822,9 +64829,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00650--mixed5a-00659.jpg-->
-    
+
 
 
 
@@ -65489,7 +65496,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -65499,7 +65506,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -65556,7 +65563,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -65566,7 +65573,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -65623,7 +65630,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -65633,7 +65640,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -65690,7 +65697,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -65700,7 +65707,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -65757,7 +65764,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -65767,7 +65774,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -65824,7 +65831,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -65834,7 +65841,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -65891,7 +65898,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -65901,7 +65908,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -65958,7 +65965,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -65968,7 +65975,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -66025,7 +66032,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -66035,7 +66042,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -66092,7 +66099,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -66102,7 +66109,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -66144,9 +66151,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00660--mixed5a-00669.jpg-->
-    
+
 
 
 
@@ -66821,7 +66828,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -66831,7 +66838,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -66888,7 +66895,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -66898,7 +66905,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -66955,7 +66962,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -66965,7 +66972,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -67022,7 +67029,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -67032,7 +67039,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -67089,7 +67096,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -67099,7 +67106,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -67156,7 +67163,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -67166,7 +67173,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -67223,7 +67230,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -67233,7 +67240,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -67290,7 +67297,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -67300,7 +67307,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -67357,7 +67364,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -67367,7 +67374,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -67424,7 +67431,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -67434,7 +67441,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -67476,9 +67483,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00670--mixed5a-00679.jpg-->
-    
+
 
 
 
@@ -68163,7 +68170,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -68173,7 +68180,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -68230,7 +68237,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -68240,7 +68247,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -68297,7 +68304,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -68307,7 +68314,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -68364,7 +68371,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -68374,7 +68381,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -68431,7 +68438,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -68441,7 +68448,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -68498,7 +68505,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -68508,7 +68515,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -68565,7 +68572,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -68575,7 +68582,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -68632,7 +68639,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -68642,7 +68649,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -68699,7 +68706,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -68709,7 +68716,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -68766,7 +68773,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -68776,7 +68783,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -68818,9 +68825,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00680--mixed5a-00689.jpg-->
-    
+
 
 
 
@@ -69515,7 +69522,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -69525,7 +69532,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -69582,7 +69589,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -69592,7 +69599,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -69649,7 +69656,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -69659,7 +69666,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -69716,7 +69723,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -69726,7 +69733,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -69783,7 +69790,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -69793,7 +69800,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -69850,7 +69857,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -69860,7 +69867,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -69917,7 +69924,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -69927,7 +69934,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -69984,7 +69991,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -69994,7 +70001,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -70051,7 +70058,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -70061,7 +70068,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -70118,7 +70125,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -70128,7 +70135,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -70170,9 +70177,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00690--mixed5a-00699.jpg-->
-    
+
 
 
 
@@ -70877,7 +70884,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -70887,7 +70894,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -70944,7 +70951,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -70954,7 +70961,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -71011,7 +71018,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -71021,7 +71028,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -71078,7 +71085,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -71088,7 +71095,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -71145,7 +71152,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -71155,7 +71162,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -71212,7 +71219,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -71222,7 +71229,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -71279,7 +71286,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -71289,7 +71296,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -71346,7 +71353,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -71356,7 +71363,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -71413,7 +71420,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -71423,7 +71430,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -71480,7 +71487,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -71490,7 +71497,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -71532,9 +71539,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00700--mixed5a-00709.jpg-->
-    
+
 
 
 
@@ -72249,7 +72256,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -72259,7 +72266,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -72316,7 +72323,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -72326,7 +72333,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -72383,7 +72390,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -72393,7 +72400,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -72450,7 +72457,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -72460,7 +72467,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -72517,7 +72524,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -72527,7 +72534,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -72584,7 +72591,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -72594,7 +72601,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -72651,7 +72658,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -72661,7 +72668,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -72718,7 +72725,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -72728,7 +72735,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -72785,7 +72792,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -72795,7 +72802,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -72852,7 +72859,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -72862,7 +72869,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -72904,9 +72911,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00710--mixed5a-00719.jpg-->
-    
+
 
 
 
@@ -73631,7 +73638,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -73641,7 +73648,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -73698,7 +73705,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -73708,7 +73715,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -73765,7 +73772,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -73775,7 +73782,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -73832,7 +73839,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -73842,7 +73849,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -73899,7 +73906,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -73909,7 +73916,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -73966,7 +73973,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -73976,7 +73983,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -74033,7 +74040,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -74043,7 +74050,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -74100,7 +74107,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -74110,7 +74117,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -74167,7 +74174,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -74177,7 +74184,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -74234,7 +74241,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -74244,7 +74251,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -74286,9 +74293,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00720--mixed5a-00729.jpg-->
-    
+
 
 
 
@@ -75023,7 +75030,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -75033,7 +75040,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -75090,7 +75097,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -75100,7 +75107,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -75157,7 +75164,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -75167,7 +75174,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -75224,7 +75231,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -75234,7 +75241,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -75291,7 +75298,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -75301,7 +75308,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -75358,7 +75365,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -75368,7 +75375,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -75425,7 +75432,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -75435,7 +75442,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -75492,7 +75499,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -75502,7 +75509,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -75559,7 +75566,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -75569,7 +75576,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -75626,7 +75633,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -75636,7 +75643,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -75678,9 +75685,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00730--mixed5a-00739.jpg-->
-    
+
 
 
 
@@ -76425,7 +76432,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -76435,7 +76442,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -76492,7 +76499,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -76502,7 +76509,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -76559,7 +76566,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -76569,7 +76576,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -76626,7 +76633,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -76636,7 +76643,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -76693,7 +76700,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -76703,7 +76710,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -76760,7 +76767,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -76770,7 +76777,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -76827,7 +76834,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -76837,7 +76844,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -76894,7 +76901,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -76904,7 +76911,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -76961,7 +76968,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -76971,7 +76978,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -77028,7 +77035,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -77038,7 +77045,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -77080,9 +77087,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00740--mixed5a-00749.jpg-->
-    
+
 
 
 
@@ -77837,7 +77844,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -77847,7 +77854,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -77904,7 +77911,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -77914,7 +77921,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -77971,7 +77978,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -77981,7 +77988,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -78038,7 +78045,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -78048,7 +78055,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -78105,7 +78112,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -78115,7 +78122,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -78172,7 +78179,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -78182,7 +78189,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -78239,7 +78246,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -78249,7 +78256,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -78306,7 +78313,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -78316,7 +78323,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -78373,7 +78380,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -78383,7 +78390,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -78440,7 +78447,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -78450,7 +78457,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -78492,9 +78499,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00750--mixed5a-00759.jpg-->
-    
+
 
 
 
@@ -79259,7 +79266,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -79269,7 +79276,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -79326,7 +79333,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -79336,7 +79343,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -79393,7 +79400,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -79403,7 +79410,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -79460,7 +79467,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -79470,7 +79477,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -79527,7 +79534,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -79537,7 +79544,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -79594,7 +79601,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -79604,7 +79611,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -79661,7 +79668,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -79671,7 +79678,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -79728,7 +79735,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -79738,7 +79745,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -79795,7 +79802,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -79805,7 +79812,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -79862,7 +79869,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -79872,7 +79879,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -79914,9 +79921,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00760--mixed5a-00769.jpg-->
-    
+
 
 
 
@@ -80691,7 +80698,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -80701,7 +80708,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -80758,7 +80765,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -80768,7 +80775,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -80825,7 +80832,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -80835,7 +80842,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -80892,7 +80899,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -80902,7 +80909,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -80959,7 +80966,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -80969,7 +80976,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -81026,7 +81033,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -81036,7 +81043,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -81093,7 +81100,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -81103,7 +81110,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -81160,7 +81167,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -81170,7 +81177,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -81227,7 +81234,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -81237,7 +81244,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -81294,7 +81301,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -81304,7 +81311,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -81346,9 +81353,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00770--mixed5a-00779.jpg-->
-    
+
 
 
 
@@ -82133,7 +82140,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -82143,7 +82150,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -82200,7 +82207,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -82210,7 +82217,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -82267,7 +82274,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -82277,7 +82284,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -82334,7 +82341,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -82344,7 +82351,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -82401,7 +82408,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -82411,7 +82418,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -82468,7 +82475,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -82478,7 +82485,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -82535,7 +82542,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -82545,7 +82552,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -82602,7 +82609,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -82612,7 +82619,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -82669,7 +82676,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -82679,7 +82686,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -82736,7 +82743,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -82746,7 +82753,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -82788,9 +82795,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00780--mixed5a-00789.jpg-->
-    
+
 
 
 
@@ -83585,7 +83592,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -83595,7 +83602,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -83652,7 +83659,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -83662,7 +83669,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -83719,7 +83726,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -83729,7 +83736,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -83786,7 +83793,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -83796,7 +83803,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -83853,7 +83860,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -83863,7 +83870,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -83920,7 +83927,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -83930,7 +83937,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -83987,7 +83994,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -83997,7 +84004,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -84054,7 +84061,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -84064,7 +84071,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -84121,7 +84128,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -84131,7 +84138,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -84188,7 +84195,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -84198,7 +84205,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -84240,9 +84247,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00790--mixed5a-00799.jpg-->
-    
+
 
 
 
@@ -85047,7 +85054,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -85057,7 +85064,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -85114,7 +85121,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -85124,7 +85131,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -85181,7 +85188,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -85191,7 +85198,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -85248,7 +85255,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -85258,7 +85265,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -85315,7 +85322,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -85325,7 +85332,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -85382,7 +85389,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -85392,7 +85399,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -85449,7 +85456,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -85459,7 +85466,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -85516,7 +85523,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -85526,7 +85533,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -85583,7 +85590,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -85593,7 +85600,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -85650,7 +85657,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -85660,7 +85667,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -85702,9 +85709,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00800--mixed5a-00809.jpg-->
-    
+
 
 
 
@@ -86519,7 +86526,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -86529,7 +86536,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -86586,7 +86593,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -86596,7 +86603,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -86653,7 +86660,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -86663,7 +86670,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -86720,7 +86727,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -86730,7 +86737,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -86787,7 +86794,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -86797,7 +86804,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -86854,7 +86861,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -86864,7 +86871,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -86921,7 +86928,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -86931,7 +86938,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -86988,7 +86995,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -86998,7 +87005,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -87055,7 +87062,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -87065,7 +87072,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -87122,7 +87129,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -87132,7 +87139,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -87174,9 +87181,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00810--mixed5a-00819.jpg-->
-    
+
 
 
 
@@ -88001,7 +88008,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -88011,7 +88018,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -88068,7 +88075,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -88078,7 +88085,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -88135,7 +88142,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -88145,7 +88152,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -88202,7 +88209,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -88212,7 +88219,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -88269,7 +88276,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -88279,7 +88286,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -88336,7 +88343,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -88346,7 +88353,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -88403,7 +88410,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -88413,7 +88420,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -88470,7 +88477,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -88480,7 +88487,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -88537,7 +88544,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -88547,7 +88554,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -88604,7 +88611,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -88614,7 +88621,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -88656,9 +88663,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00820--mixed5a-00829.jpg-->
-    
+
 
 
 
@@ -89493,7 +89500,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -89503,7 +89510,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -89560,7 +89567,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -89570,7 +89577,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -89627,7 +89634,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -89637,7 +89644,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -89694,7 +89701,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -89704,7 +89711,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -89761,7 +89768,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -89771,7 +89778,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -89828,7 +89835,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -89838,7 +89845,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -89895,7 +89902,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -89905,7 +89912,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -89962,7 +89969,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -89972,7 +89979,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -90029,7 +90036,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -90039,7 +90046,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -90096,7 +90103,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -90106,7 +90113,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -90148,9 +90155,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5a-00830--mixed5a-00831.jpg-->
-    
+
 
 
 
@@ -90995,7 +91002,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -91005,7 +91012,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -91062,7 +91069,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -91072,7 +91079,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -91114,9 +91121,8 @@
       </div>
       </d-figure>
       </li>
-  
+
   </ul>
   </d-article>
   <distill-footer></distill-footer>
 </body>
-  

--- a/public/appendix/googlenet/5b.html
+++ b/public/appendix/googlenet/5b.html
@@ -5,21 +5,21 @@
   <meta charset="utf8">
   <script src="https://distill.pub/template.v2.js"></script>
   <style>
-  
+
     d-article {
       line-height: 1em;
     }
-    
+
     d-byline,
     d-appendix {
       display: none;
     }
-  
+
     h4 {
       display: block;
       width: 100%;
     }
-    
+
     d-figure {
       display: flex;
       flex-flow: row;
@@ -31,7 +31,7 @@
       margin-bottom: 1em;
       justify-content: center;
     }
-    
+
     .positive,
     .negative {
       display: flex;
@@ -40,7 +40,7 @@
       align-content: flex-start;
       max-width: 370px;
     }
-    
+
     .positive {
       padding-left: 1em;
       padding-right: 1em;
@@ -50,14 +50,14 @@
       border-right: 1px solid rgba(0,0,0,0.1);
       justify-content: space-between;
     }
-    
+
     .figcaption {
       display: block;
       color: rgba(0, 0, 0, 0.6);
       font-size: 12px;
       line-height: 1.5em;
     }
-    
+
     .diversity {
       display: flex;
       flex-flow: row;
@@ -65,61 +65,61 @@
       width: 148px;
       height: 147px
     }
-    
+
     .diversity > div {
       zoom: 0.496598639;
     }
-    
+
     .channel {
       margin-right: 1em;
     }
-    
+
     .channels {
       grid-column: screen;
       list-style: none;
       padding-left: 0;
     }
-    
+
     .channels li {
       contain: content;
       overflow: hidden;
     }
-    
+
     .sprite {
       display: inline-block;
       margin: 1px;
       width: 147px;
       height: 147px;
     }
-    
+
     .sprite.neuron {
       background-position-x: 0px;
     }
-    
+
     .sprite.channel {
       background-position-x: -147px;
     }
-    
+
     .sprite.channel-negative {
       background-position-x: -294px;
     }
-    
+
     .sprite.channel-diversity-0 {
       background-position-x: -441px;
     }
-    
+
     .sprite.channel-diversity-1 {
       background-position-x: -588px;
     }
-    
+
     .sprite.channel-diversity-2 {
       background-position-x: -735px;
     }
-    
+
     .sprite.channel-diversity-3 {
       background-position-x: -882px;
     }
-    
+
     .dataset-examples {
       display: flex;
       flex-flow: row;
@@ -127,7 +127,7 @@
       width: 375px;
       height: 147px
     }
-    
+
     .dataset-examples .sprite {
       height: 73px;
       width: 73px;
@@ -136,16 +136,16 @@
       margin-bottom: 0;
       margin-right: 0;
     }
-    
-    
+
+
       .channels .sprite.dataset-index-0 {
         background-position-x: -1029px !important;
       }
-      
+
       .channels .sprite.index-0 {
         background-position-y: -0px;
       }
-      
+
       .channels .dataset-negative .sprite.index-0 {
         background-position-y: -74px !important;
       }
@@ -153,11 +153,11 @@
       .channels .sprite.dataset-index-1 {
         background-position-x: -1103px !important;
       }
-      
+
       .channels .sprite.index-1 {
         background-position-y: -147px;
       }
-      
+
       .channels .dataset-negative .sprite.index-1 {
         background-position-y: -221px !important;
       }
@@ -165,11 +165,11 @@
       .channels .sprite.dataset-index-2 {
         background-position-x: -1177px !important;
       }
-      
+
       .channels .sprite.index-2 {
         background-position-y: -294px;
       }
-      
+
       .channels .dataset-negative .sprite.index-2 {
         background-position-y: -368px !important;
       }
@@ -177,11 +177,11 @@
       .channels .sprite.dataset-index-3 {
         background-position-x: -1251px !important;
       }
-      
+
       .channels .sprite.index-3 {
         background-position-y: -441px;
       }
-      
+
       .channels .dataset-negative .sprite.index-3 {
         background-position-y: -515px !important;
       }
@@ -189,11 +189,11 @@
       .channels .sprite.dataset-index-4 {
         background-position-x: -1325px !important;
       }
-      
+
       .channels .sprite.index-4 {
         background-position-y: -588px;
       }
-      
+
       .channels .dataset-negative .sprite.index-4 {
         background-position-y: -662px !important;
       }
@@ -201,11 +201,11 @@
       .channels .sprite.dataset-index-5 {
         background-position-x: -1399px !important;
       }
-      
+
       .channels .sprite.index-5 {
         background-position-y: -735px;
       }
-      
+
       .channels .dataset-negative .sprite.index-5 {
         background-position-y: -809px !important;
       }
@@ -213,11 +213,11 @@
       .channels .sprite.dataset-index-6 {
         background-position-x: -1473px !important;
       }
-      
+
       .channels .sprite.index-6 {
         background-position-y: -882px;
       }
-      
+
       .channels .dataset-negative .sprite.index-6 {
         background-position-y: -956px !important;
       }
@@ -225,11 +225,11 @@
       .channels .sprite.dataset-index-7 {
         background-position-x: -1547px !important;
       }
-      
+
       .channels .sprite.index-7 {
         background-position-y: -1029px;
       }
-      
+
       .channels .dataset-negative .sprite.index-7 {
         background-position-y: -1103px !important;
       }
@@ -237,11 +237,11 @@
       .channels .sprite.dataset-index-8 {
         background-position-x: -1621px !important;
       }
-      
+
       .channels .sprite.index-8 {
         background-position-y: -1176px;
       }
-      
+
       .channels .dataset-negative .sprite.index-8 {
         background-position-y: -1250px !important;
       }
@@ -249,20 +249,20 @@
       .channels .sprite.dataset-index-9 {
         background-position-x: -1695px !important;
       }
-      
+
       .channels .sprite.index-9 {
         background-position-y: -1323px;
       }
-      
+
       .channels .dataset-negative .sprite.index-9 {
         background-position-y: -1397px !important;
       }
-    
-    
+
+
     .article-nav {
       grid-column: page;
     }
-    
+
     .navlist li {
       display: inline;
       list-style-type: none;
@@ -300,10 +300,10 @@
     <h1>Layer 5b</h1>
   </d-title>
   <d-article>
-  
+
   <nav class="article-nav">
-  
-    
+
+
     <ul class="navlist">
       <li><a href="https://distill.pub/2017/feature-visualization/appendix/">Appendix overview</a></li>
       <li><a href="https://distill.pub/2017/feature-visualization/">Main article</a></li>
@@ -334,17 +334,24 @@
         <a href="5a.html">Layer 5a</a>
       </li>
       <li>
-        <a href="5b.html">Layer 5b</a>
+        <a href="5b.html"><b>Layer 5b</b></a>
       </li>
     </ul>
-  
+
+    <ul class="navlist">
+      <li> <a href="5b.html#5b-0">5b 1x1</a> <span style="color: #777;">(0:384)</span> </li>
+      <li> <a href="5b.html#5b-384">5b 3x3</a> <span style="color: #777;">(384:768)</span> </li>
+      <li> <a href="5b.html#5b-768">5b 5x5</a> <span style="color: #777;">(768:896)</span> </li>
+      <li> <a href="5b.html#5b-896">5b pool</a> <span style="color: #777;">(896:1024)</span> </li>
+    </ul>
+
   </nav>
-  
+
   <hr style="margin-top: 20px;"/>
-  
+
   <ul class="channels">
     <!--mixed5b-00000--mixed5b-00009.jpg-->
-    
+
       <li id="channel-0">
       <d-figure id="5b-0">
       <style data-img-src="images/mixed5b-00000--mixed5b-00009.jpg" data-channel="0"></style>
@@ -359,7 +366,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -369,7 +376,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -426,7 +433,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -436,7 +443,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -493,7 +500,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -503,7 +510,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -560,7 +567,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -570,7 +577,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -627,7 +634,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -637,7 +644,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -694,7 +701,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -704,7 +711,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -761,7 +768,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -771,7 +778,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -828,7 +835,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -838,7 +845,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -895,7 +902,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -905,7 +912,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -962,7 +969,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -972,7 +979,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -1014,9 +1021,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00010--mixed5b-00019.jpg-->
-    
+
 
 
 
@@ -1041,7 +1048,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -1051,7 +1058,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -1108,7 +1115,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -1118,7 +1125,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -1175,7 +1182,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -1185,7 +1192,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -1242,7 +1249,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -1252,7 +1259,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -1309,7 +1316,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -1319,7 +1326,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -1376,7 +1383,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -1386,7 +1393,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -1443,7 +1450,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -1453,7 +1460,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -1510,7 +1517,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -1520,7 +1527,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -1577,7 +1584,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -1587,7 +1594,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -1644,7 +1651,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -1654,7 +1661,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -1696,9 +1703,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00020--mixed5b-00029.jpg-->
-    
+
 
 
 
@@ -1733,7 +1740,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -1743,7 +1750,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -1800,7 +1807,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -1810,7 +1817,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -1867,7 +1874,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -1877,7 +1884,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -1934,7 +1941,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -1944,7 +1951,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -2001,7 +2008,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -2011,7 +2018,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -2068,7 +2075,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -2078,7 +2085,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -2135,7 +2142,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -2145,7 +2152,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -2202,7 +2209,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -2212,7 +2219,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -2269,7 +2276,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -2279,7 +2286,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -2336,7 +2343,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -2346,7 +2353,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -2388,9 +2395,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00030--mixed5b-00039.jpg-->
-    
+
 
 
 
@@ -2435,7 +2442,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -2445,7 +2452,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -2502,7 +2509,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -2512,7 +2519,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -2569,7 +2576,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -2579,7 +2586,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -2636,7 +2643,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -2646,7 +2653,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -2703,7 +2710,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -2713,7 +2720,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -2770,7 +2777,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -2780,7 +2787,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -2837,7 +2844,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -2847,7 +2854,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -2904,7 +2911,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -2914,7 +2921,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -2971,7 +2978,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -2981,7 +2988,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -3038,7 +3045,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -3048,7 +3055,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -3090,9 +3097,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00040--mixed5b-00049.jpg-->
-    
+
 
 
 
@@ -3147,7 +3154,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -3157,7 +3164,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -3214,7 +3221,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -3224,7 +3231,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -3281,7 +3288,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -3291,7 +3298,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -3348,7 +3355,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -3358,7 +3365,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -3415,7 +3422,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -3425,7 +3432,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -3482,7 +3489,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -3492,7 +3499,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -3549,7 +3556,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -3559,7 +3566,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -3616,7 +3623,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -3626,7 +3633,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -3683,7 +3690,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -3693,7 +3700,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -3750,7 +3757,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -3760,7 +3767,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -3802,9 +3809,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00050--mixed5b-00059.jpg-->
-    
+
 
 
 
@@ -3869,7 +3876,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -3879,7 +3886,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -3936,7 +3943,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -3946,7 +3953,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -4003,7 +4010,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -4013,7 +4020,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -4070,7 +4077,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -4080,7 +4087,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -4137,7 +4144,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -4147,7 +4154,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -4204,7 +4211,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -4214,7 +4221,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -4271,7 +4278,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -4281,7 +4288,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -4338,7 +4345,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -4348,7 +4355,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -4405,7 +4412,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -4415,7 +4422,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -4472,7 +4479,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -4482,7 +4489,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -4524,9 +4531,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00060--mixed5b-00069.jpg-->
-    
+
 
 
 
@@ -4601,7 +4608,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -4611,7 +4618,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -4668,7 +4675,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -4678,7 +4685,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -4735,7 +4742,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -4745,7 +4752,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -4802,7 +4809,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -4812,7 +4819,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -4869,7 +4876,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -4879,7 +4886,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -4936,7 +4943,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -4946,7 +4953,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -5003,7 +5010,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -5013,7 +5020,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -5070,7 +5077,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -5080,7 +5087,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -5137,7 +5144,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -5147,7 +5154,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -5204,7 +5211,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -5214,7 +5221,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -5256,9 +5263,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00070--mixed5b-00079.jpg-->
-    
+
 
 
 
@@ -5343,7 +5350,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -5353,7 +5360,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -5410,7 +5417,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -5420,7 +5427,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -5477,7 +5484,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -5487,7 +5494,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -5544,7 +5551,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -5554,7 +5561,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -5611,7 +5618,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -5621,7 +5628,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -5678,7 +5685,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -5688,7 +5695,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -5745,7 +5752,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -5755,7 +5762,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -5812,7 +5819,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -5822,7 +5829,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -5879,7 +5886,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -5889,7 +5896,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -5946,7 +5953,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -5956,7 +5963,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -5998,9 +6005,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00080--mixed5b-00089.jpg-->
-    
+
 
 
 
@@ -6095,7 +6102,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -6105,7 +6112,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -6162,7 +6169,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -6172,7 +6179,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -6229,7 +6236,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -6239,7 +6246,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -6296,7 +6303,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -6306,7 +6313,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -6363,7 +6370,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -6373,7 +6380,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -6430,7 +6437,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -6440,7 +6447,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -6497,7 +6504,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -6507,7 +6514,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -6564,7 +6571,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -6574,7 +6581,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -6631,7 +6638,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -6641,7 +6648,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -6698,7 +6705,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -6708,7 +6715,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -6750,9 +6757,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00090--mixed5b-00099.jpg-->
-    
+
 
 
 
@@ -6857,7 +6864,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -6867,7 +6874,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -6924,7 +6931,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -6934,7 +6941,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -6991,7 +6998,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -7001,7 +7008,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -7058,7 +7065,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -7068,7 +7075,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -7125,7 +7132,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -7135,7 +7142,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -7192,7 +7199,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -7202,7 +7209,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -7259,7 +7266,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -7269,7 +7276,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -7326,7 +7333,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -7336,7 +7343,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -7393,7 +7400,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -7403,7 +7410,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -7460,7 +7467,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -7470,7 +7477,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -7512,9 +7519,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00100--mixed5b-00109.jpg-->
-    
+
 
 
 
@@ -7629,7 +7636,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -7639,7 +7646,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -7696,7 +7703,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -7706,7 +7713,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -7763,7 +7770,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -7773,7 +7780,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -7830,7 +7837,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -7840,7 +7847,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -7897,7 +7904,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -7907,7 +7914,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -7964,7 +7971,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -7974,7 +7981,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -8031,7 +8038,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -8041,7 +8048,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -8098,7 +8105,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -8108,7 +8115,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -8165,7 +8172,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -8175,7 +8182,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -8232,7 +8239,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -8242,7 +8249,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -8284,9 +8291,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00110--mixed5b-00119.jpg-->
-    
+
 
 
 
@@ -8411,7 +8418,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -8421,7 +8428,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -8478,7 +8485,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -8488,7 +8495,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -8545,7 +8552,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -8555,7 +8562,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -8612,7 +8619,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -8622,7 +8629,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -8679,7 +8686,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -8689,7 +8696,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -8746,7 +8753,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -8756,7 +8763,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -8813,7 +8820,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -8823,7 +8830,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -8880,7 +8887,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -8890,7 +8897,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -8947,7 +8954,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -8957,7 +8964,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -9014,7 +9021,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -9024,7 +9031,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -9066,9 +9073,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00120--mixed5b-00129.jpg-->
-    
+
 
 
 
@@ -9203,7 +9210,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -9213,7 +9220,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -9270,7 +9277,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -9280,7 +9287,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -9337,7 +9344,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -9347,7 +9354,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -9404,7 +9411,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -9414,7 +9421,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -9471,7 +9478,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -9481,7 +9488,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -9538,7 +9545,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -9548,7 +9555,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -9605,7 +9612,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -9615,7 +9622,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -9672,7 +9679,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -9682,7 +9689,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -9739,7 +9746,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -9749,7 +9756,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -9806,7 +9813,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -9816,7 +9823,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -9858,9 +9865,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00130--mixed5b-00139.jpg-->
-    
+
 
 
 
@@ -10005,7 +10012,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -10015,7 +10022,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -10072,7 +10079,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -10082,7 +10089,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -10139,7 +10146,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -10149,7 +10156,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -10206,7 +10213,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -10216,7 +10223,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -10273,7 +10280,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -10283,7 +10290,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -10340,7 +10347,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -10350,7 +10357,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -10407,7 +10414,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -10417,7 +10424,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -10474,7 +10481,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -10484,7 +10491,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -10541,7 +10548,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -10551,7 +10558,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -10608,7 +10615,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -10618,7 +10625,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -10660,9 +10667,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00140--mixed5b-00149.jpg-->
-    
+
 
 
 
@@ -10817,7 +10824,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -10827,7 +10834,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -10884,7 +10891,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -10894,7 +10901,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -10951,7 +10958,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -10961,7 +10968,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -11018,7 +11025,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -11028,7 +11035,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -11085,7 +11092,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -11095,7 +11102,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -11152,7 +11159,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -11162,7 +11169,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -11219,7 +11226,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -11229,7 +11236,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -11286,7 +11293,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -11296,7 +11303,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -11353,7 +11360,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -11363,7 +11370,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -11420,7 +11427,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -11430,7 +11437,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -11472,9 +11479,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00150--mixed5b-00159.jpg-->
-    
+
 
 
 
@@ -11639,7 +11646,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -11649,7 +11656,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -11706,7 +11713,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -11716,7 +11723,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -11773,7 +11780,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -11783,7 +11790,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -11840,7 +11847,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -11850,7 +11857,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -11907,7 +11914,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -11917,7 +11924,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -11974,7 +11981,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -11984,7 +11991,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -12041,7 +12048,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -12051,7 +12058,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -12108,7 +12115,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -12118,7 +12125,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -12175,7 +12182,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -12185,7 +12192,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -12242,7 +12249,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -12252,7 +12259,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -12294,9 +12301,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00160--mixed5b-00169.jpg-->
-    
+
 
 
 
@@ -12471,7 +12478,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -12481,7 +12488,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -12538,7 +12545,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -12548,7 +12555,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -12605,7 +12612,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -12615,7 +12622,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -12672,7 +12679,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -12682,7 +12689,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -12739,7 +12746,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -12749,7 +12756,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -12806,7 +12813,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -12816,7 +12823,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -12873,7 +12880,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -12883,7 +12890,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -12940,7 +12947,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -12950,7 +12957,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -13007,7 +13014,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -13017,7 +13024,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -13074,7 +13081,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -13084,7 +13091,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -13126,9 +13133,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00170--mixed5b-00179.jpg-->
-    
+
 
 
 
@@ -13313,7 +13320,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -13323,7 +13330,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -13380,7 +13387,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -13390,7 +13397,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -13447,7 +13454,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -13457,7 +13464,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -13514,7 +13521,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -13524,7 +13531,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -13581,7 +13588,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -13591,7 +13598,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -13648,7 +13655,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -13658,7 +13665,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -13715,7 +13722,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -13725,7 +13732,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -13782,7 +13789,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -13792,7 +13799,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -13849,7 +13856,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -13859,7 +13866,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -13916,7 +13923,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -13926,7 +13933,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -13968,9 +13975,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00180--mixed5b-00189.jpg-->
-    
+
 
 
 
@@ -14165,7 +14172,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -14175,7 +14182,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -14232,7 +14239,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -14242,7 +14249,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -14299,7 +14306,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -14309,7 +14316,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -14366,7 +14373,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -14376,7 +14383,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -14433,7 +14440,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -14443,7 +14450,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -14500,7 +14507,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -14510,7 +14517,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -14567,7 +14574,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -14577,7 +14584,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -14634,7 +14641,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -14644,7 +14651,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -14701,7 +14708,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -14711,7 +14718,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -14768,7 +14775,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -14778,7 +14785,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -14820,9 +14827,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00190--mixed5b-00199.jpg-->
-    
+
 
 
 
@@ -15027,7 +15034,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -15037,7 +15044,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -15094,7 +15101,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -15104,7 +15111,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -15161,7 +15168,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -15171,7 +15178,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -15228,7 +15235,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -15238,7 +15245,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -15295,7 +15302,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -15305,7 +15312,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -15362,7 +15369,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -15372,7 +15379,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -15429,7 +15436,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -15439,7 +15446,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -15496,7 +15503,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -15506,7 +15513,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -15563,7 +15570,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -15573,7 +15580,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -15630,7 +15637,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -15640,7 +15647,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -15682,9 +15689,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00200--mixed5b-00209.jpg-->
-    
+
 
 
 
@@ -15899,7 +15906,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -15909,7 +15916,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -15966,7 +15973,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -15976,7 +15983,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -16033,7 +16040,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -16043,7 +16050,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -16100,7 +16107,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -16110,7 +16117,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -16167,7 +16174,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -16177,7 +16184,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -16234,7 +16241,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -16244,7 +16251,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -16301,7 +16308,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -16311,7 +16318,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -16368,7 +16375,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -16378,7 +16385,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -16435,7 +16442,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -16445,7 +16452,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -16502,7 +16509,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -16512,7 +16519,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -16554,9 +16561,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00210--mixed5b-00219.jpg-->
-    
+
 
 
 
@@ -16781,7 +16788,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -16791,7 +16798,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -16848,7 +16855,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -16858,7 +16865,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -16915,7 +16922,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -16925,7 +16932,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -16982,7 +16989,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -16992,7 +16999,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -17049,7 +17056,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -17059,7 +17066,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -17116,7 +17123,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -17126,7 +17133,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -17183,7 +17190,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -17193,7 +17200,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -17250,7 +17257,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -17260,7 +17267,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -17317,7 +17324,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -17327,7 +17334,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -17384,7 +17391,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -17394,7 +17401,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -17436,9 +17443,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00220--mixed5b-00229.jpg-->
-    
+
 
 
 
@@ -17673,7 +17680,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -17683,7 +17690,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -17740,7 +17747,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -17750,7 +17757,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -17807,7 +17814,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -17817,7 +17824,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -17874,7 +17881,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -17884,7 +17891,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -17941,7 +17948,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -17951,7 +17958,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -18008,7 +18015,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -18018,7 +18025,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -18075,7 +18082,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -18085,7 +18092,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -18142,7 +18149,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -18152,7 +18159,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -18209,7 +18216,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -18219,7 +18226,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -18276,7 +18283,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -18286,7 +18293,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -18328,9 +18335,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00230--mixed5b-00239.jpg-->
-    
+
 
 
 
@@ -18575,7 +18582,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -18585,7 +18592,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -18642,7 +18649,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -18652,7 +18659,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -18709,7 +18716,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -18719,7 +18726,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -18776,7 +18783,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -18786,7 +18793,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -18843,7 +18850,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -18853,7 +18860,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -18910,7 +18917,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -18920,7 +18927,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -18977,7 +18984,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -18987,7 +18994,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -19044,7 +19051,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -19054,7 +19061,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -19111,7 +19118,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -19121,7 +19128,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -19178,7 +19185,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -19188,7 +19195,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -19230,9 +19237,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00240--mixed5b-00249.jpg-->
-    
+
 
 
 
@@ -19487,7 +19494,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -19497,7 +19504,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -19554,7 +19561,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -19564,7 +19571,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -19621,7 +19628,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -19631,7 +19638,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -19688,7 +19695,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -19698,7 +19705,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -19755,7 +19762,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -19765,7 +19772,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -19822,7 +19829,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -19832,7 +19839,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -19889,7 +19896,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -19899,7 +19906,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -19956,7 +19963,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -19966,7 +19973,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -20023,7 +20030,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -20033,7 +20040,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -20090,7 +20097,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -20100,7 +20107,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -20142,9 +20149,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00250--mixed5b-00259.jpg-->
-    
+
 
 
 
@@ -20409,7 +20416,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -20419,7 +20426,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -20476,7 +20483,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -20486,7 +20493,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -20543,7 +20550,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -20553,7 +20560,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -20610,7 +20617,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -20620,7 +20627,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -20677,7 +20684,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -20687,7 +20694,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -20744,7 +20751,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -20754,7 +20761,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -20811,7 +20818,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -20821,7 +20828,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -20878,7 +20885,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -20888,7 +20895,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -20945,7 +20952,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -20955,7 +20962,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -21012,7 +21019,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -21022,7 +21029,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -21064,9 +21071,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00260--mixed5b-00269.jpg-->
-    
+
 
 
 
@@ -21341,7 +21348,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -21351,7 +21358,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -21408,7 +21415,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -21418,7 +21425,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -21475,7 +21482,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -21485,7 +21492,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -21542,7 +21549,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -21552,7 +21559,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -21609,7 +21616,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -21619,7 +21626,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -21676,7 +21683,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -21686,7 +21693,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -21743,7 +21750,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -21753,7 +21760,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -21810,7 +21817,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -21820,7 +21827,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -21877,7 +21884,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -21887,7 +21894,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -21944,7 +21951,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -21954,7 +21961,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -21996,9 +22003,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00270--mixed5b-00279.jpg-->
-    
+
 
 
 
@@ -22283,7 +22290,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -22293,7 +22300,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -22350,7 +22357,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -22360,7 +22367,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -22417,7 +22424,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -22427,7 +22434,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -22484,7 +22491,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -22494,7 +22501,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -22551,7 +22558,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -22561,7 +22568,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -22618,7 +22625,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -22628,7 +22635,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -22685,7 +22692,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -22695,7 +22702,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -22752,7 +22759,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -22762,7 +22769,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -22819,7 +22826,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -22829,7 +22836,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -22886,7 +22893,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -22896,7 +22903,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -22938,9 +22945,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00280--mixed5b-00289.jpg-->
-    
+
 
 
 
@@ -23235,7 +23242,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -23245,7 +23252,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -23302,7 +23309,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -23312,7 +23319,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -23369,7 +23376,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -23379,7 +23386,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -23436,7 +23443,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -23446,7 +23453,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -23503,7 +23510,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -23513,7 +23520,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -23570,7 +23577,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -23580,7 +23587,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -23637,7 +23644,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -23647,7 +23654,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -23704,7 +23711,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -23714,7 +23721,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -23771,7 +23778,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -23781,7 +23788,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -23838,7 +23845,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -23848,7 +23855,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -23890,9 +23897,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00290--mixed5b-00299.jpg-->
-    
+
 
 
 
@@ -24197,7 +24204,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -24207,7 +24214,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -24264,7 +24271,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -24274,7 +24281,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -24331,7 +24338,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -24341,7 +24348,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -24398,7 +24405,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -24408,7 +24415,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -24465,7 +24472,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -24475,7 +24482,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -24532,7 +24539,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -24542,7 +24549,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -24599,7 +24606,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -24609,7 +24616,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -24666,7 +24673,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -24676,7 +24683,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -24733,7 +24740,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -24743,7 +24750,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -24800,7 +24807,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -24810,7 +24817,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -24852,9 +24859,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00300--mixed5b-00309.jpg-->
-    
+
 
 
 
@@ -25169,7 +25176,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -25179,7 +25186,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -25236,7 +25243,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -25246,7 +25253,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -25303,7 +25310,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -25313,7 +25320,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -25370,7 +25377,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -25380,7 +25387,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -25437,7 +25444,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -25447,7 +25454,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -25504,7 +25511,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -25514,7 +25521,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -25571,7 +25578,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -25581,7 +25588,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -25638,7 +25645,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -25648,7 +25655,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -25705,7 +25712,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -25715,7 +25722,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -25772,7 +25779,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -25782,7 +25789,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -25824,9 +25831,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00310--mixed5b-00319.jpg-->
-    
+
 
 
 
@@ -26151,7 +26158,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -26161,7 +26168,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -26218,7 +26225,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -26228,7 +26235,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -26285,7 +26292,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -26295,7 +26302,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -26352,7 +26359,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -26362,7 +26369,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -26419,7 +26426,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -26429,7 +26436,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -26486,7 +26493,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -26496,7 +26503,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -26553,7 +26560,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -26563,7 +26570,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -26620,7 +26627,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -26630,7 +26637,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -26687,7 +26694,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -26697,7 +26704,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -26754,7 +26761,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -26764,7 +26771,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -26806,9 +26813,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00320--mixed5b-00329.jpg-->
-    
+
 
 
 
@@ -27143,7 +27150,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -27153,7 +27160,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -27210,7 +27217,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -27220,7 +27227,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -27277,7 +27284,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -27287,7 +27294,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -27344,7 +27351,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -27354,7 +27361,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -27411,7 +27418,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -27421,7 +27428,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -27478,7 +27485,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -27488,7 +27495,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -27545,7 +27552,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -27555,7 +27562,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -27612,7 +27619,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -27622,7 +27629,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -27679,7 +27686,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -27689,7 +27696,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -27746,7 +27753,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -27756,7 +27763,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -27798,9 +27805,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00330--mixed5b-00339.jpg-->
-    
+
 
 
 
@@ -28145,7 +28152,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -28155,7 +28162,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -28212,7 +28219,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -28222,7 +28229,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -28279,7 +28286,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -28289,7 +28296,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -28346,7 +28353,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -28356,7 +28363,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -28413,7 +28420,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -28423,7 +28430,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -28480,7 +28487,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -28490,7 +28497,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -28547,7 +28554,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -28557,7 +28564,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -28614,7 +28621,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -28624,7 +28631,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -28681,7 +28688,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -28691,7 +28698,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -28748,7 +28755,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -28758,7 +28765,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -28800,9 +28807,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00340--mixed5b-00349.jpg-->
-    
+
 
 
 
@@ -29157,7 +29164,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -29167,7 +29174,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -29224,7 +29231,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -29234,7 +29241,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -29291,7 +29298,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -29301,7 +29308,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -29358,7 +29365,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -29368,7 +29375,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -29425,7 +29432,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -29435,7 +29442,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -29492,7 +29499,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -29502,7 +29509,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -29559,7 +29566,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -29569,7 +29576,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -29626,7 +29633,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -29636,7 +29643,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -29693,7 +29700,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -29703,7 +29710,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -29760,7 +29767,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -29770,7 +29777,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -29812,9 +29819,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00350--mixed5b-00359.jpg-->
-    
+
 
 
 
@@ -30179,7 +30186,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -30189,7 +30196,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -30246,7 +30253,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -30256,7 +30263,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -30313,7 +30320,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -30323,7 +30330,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -30380,7 +30387,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -30390,7 +30397,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -30447,7 +30454,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -30457,7 +30464,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -30514,7 +30521,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -30524,7 +30531,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -30581,7 +30588,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -30591,7 +30598,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -30648,7 +30655,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -30658,7 +30665,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -30715,7 +30722,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -30725,7 +30732,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -30782,7 +30789,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -30792,7 +30799,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -30834,9 +30841,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00360--mixed5b-00369.jpg-->
-    
+
 
 
 
@@ -31211,7 +31218,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -31221,7 +31228,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -31278,7 +31285,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -31288,7 +31295,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -31345,7 +31352,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -31355,7 +31362,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -31412,7 +31419,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -31422,7 +31429,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -31479,7 +31486,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -31489,7 +31496,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -31546,7 +31553,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -31556,7 +31563,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -31613,7 +31620,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -31623,7 +31630,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -31680,7 +31687,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -31690,7 +31697,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -31747,7 +31754,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -31757,7 +31764,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -31814,7 +31821,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -31824,7 +31831,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -31866,9 +31873,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00370--mixed5b-00379.jpg-->
-    
+
 
 
 
@@ -32253,7 +32260,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -32263,7 +32270,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -32320,7 +32327,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -32330,7 +32337,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -32387,7 +32394,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -32397,7 +32404,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -32454,7 +32461,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -32464,7 +32471,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -32521,7 +32528,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -32531,7 +32538,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -32588,7 +32595,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -32598,7 +32605,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -32655,7 +32662,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -32665,7 +32672,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -32722,7 +32729,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -32732,7 +32739,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -32789,7 +32796,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -32799,7 +32806,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -32856,7 +32863,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -32866,7 +32873,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -32908,9 +32915,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00380--mixed5b-00389.jpg-->
-    
+
 
 
 
@@ -33305,7 +33312,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -33315,7 +33322,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -33372,7 +33379,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -33382,7 +33389,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -33439,7 +33446,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -33449,7 +33456,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -33506,7 +33513,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -33516,7 +33523,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -33573,7 +33580,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -33583,7 +33590,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -33640,7 +33647,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -33650,7 +33657,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -33707,7 +33714,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -33717,7 +33724,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -33774,7 +33781,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -33784,7 +33791,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -33841,7 +33848,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -33851,7 +33858,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -33908,7 +33915,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -33918,7 +33925,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -33960,9 +33967,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00390--mixed5b-00399.jpg-->
-    
+
 
 
 
@@ -34367,7 +34374,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -34377,7 +34384,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -34434,7 +34441,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -34444,7 +34451,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -34501,7 +34508,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -34511,7 +34518,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -34568,7 +34575,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -34578,7 +34585,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -34635,7 +34642,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -34645,7 +34652,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -34702,7 +34709,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -34712,7 +34719,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -34769,7 +34776,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -34779,7 +34786,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -34836,7 +34843,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -34846,7 +34853,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -34903,7 +34910,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -34913,7 +34920,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -34970,7 +34977,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -34980,7 +34987,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -35022,9 +35029,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00400--mixed5b-00409.jpg-->
-    
+
 
 
 
@@ -35439,7 +35446,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -35449,7 +35456,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -35506,7 +35513,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -35516,7 +35523,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -35573,7 +35580,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -35583,7 +35590,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -35640,7 +35647,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -35650,7 +35657,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -35707,7 +35714,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -35717,7 +35724,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -35774,7 +35781,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -35784,7 +35791,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -35841,7 +35848,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -35851,7 +35858,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -35908,7 +35915,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -35918,7 +35925,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -35975,7 +35982,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -35985,7 +35992,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -36042,7 +36049,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -36052,7 +36059,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -36094,9 +36101,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00410--mixed5b-00419.jpg-->
-    
+
 
 
 
@@ -36521,7 +36528,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -36531,7 +36538,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -36588,7 +36595,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -36598,7 +36605,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -36655,7 +36662,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -36665,7 +36672,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -36722,7 +36729,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -36732,7 +36739,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -36789,7 +36796,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -36799,7 +36806,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -36856,7 +36863,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -36866,7 +36873,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -36923,7 +36930,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -36933,7 +36940,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -36990,7 +36997,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -37000,7 +37007,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -37057,7 +37064,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -37067,7 +37074,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -37124,7 +37131,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -37134,7 +37141,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -37176,9 +37183,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00420--mixed5b-00429.jpg-->
-    
+
 
 
 
@@ -37613,7 +37620,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -37623,7 +37630,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -37680,7 +37687,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -37690,7 +37697,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -37747,7 +37754,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -37757,7 +37764,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -37814,7 +37821,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -37824,7 +37831,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -37881,7 +37888,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -37891,7 +37898,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -37948,7 +37955,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -37958,7 +37965,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -38015,7 +38022,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -38025,7 +38032,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -38082,7 +38089,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -38092,7 +38099,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -38149,7 +38156,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -38159,7 +38166,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -38216,7 +38223,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -38226,7 +38233,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -38268,9 +38275,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00430--mixed5b-00439.jpg-->
-    
+
 
 
 
@@ -38715,7 +38722,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -38725,7 +38732,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -38782,7 +38789,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -38792,7 +38799,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -38849,7 +38856,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -38859,7 +38866,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -38916,7 +38923,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -38926,7 +38933,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -38983,7 +38990,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -38993,7 +39000,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -39050,7 +39057,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -39060,7 +39067,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -39117,7 +39124,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -39127,7 +39134,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -39184,7 +39191,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -39194,7 +39201,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -39251,7 +39258,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -39261,7 +39268,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -39318,7 +39325,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -39328,7 +39335,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -39370,9 +39377,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00440--mixed5b-00449.jpg-->
-    
+
 
 
 
@@ -39827,7 +39834,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -39837,7 +39844,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -39894,7 +39901,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -39904,7 +39911,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -39961,7 +39968,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -39971,7 +39978,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -40028,7 +40035,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -40038,7 +40045,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -40095,7 +40102,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -40105,7 +40112,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -40162,7 +40169,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -40172,7 +40179,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -40229,7 +40236,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -40239,7 +40246,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -40296,7 +40303,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -40306,7 +40313,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -40363,7 +40370,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -40373,7 +40380,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -40430,7 +40437,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -40440,7 +40447,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -40482,9 +40489,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00450--mixed5b-00459.jpg-->
-    
+
 
 
 
@@ -40949,7 +40956,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -40959,7 +40966,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -41016,7 +41023,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -41026,7 +41033,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -41083,7 +41090,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -41093,7 +41100,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -41150,7 +41157,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -41160,7 +41167,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -41217,7 +41224,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -41227,7 +41234,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -41284,7 +41291,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -41294,7 +41301,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -41351,7 +41358,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -41361,7 +41368,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -41418,7 +41425,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -41428,7 +41435,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -41485,7 +41492,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -41495,7 +41502,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -41552,7 +41559,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -41562,7 +41569,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -41604,9 +41611,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00460--mixed5b-00469.jpg-->
-    
+
 
 
 
@@ -42081,7 +42088,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -42091,7 +42098,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -42148,7 +42155,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -42158,7 +42165,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -42215,7 +42222,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -42225,7 +42232,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -42282,7 +42289,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -42292,7 +42299,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -42349,7 +42356,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -42359,7 +42366,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -42416,7 +42423,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -42426,7 +42433,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -42483,7 +42490,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -42493,7 +42500,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -42550,7 +42557,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -42560,7 +42567,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -42617,7 +42624,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -42627,7 +42634,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -42684,7 +42691,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -42694,7 +42701,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -42736,9 +42743,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00470--mixed5b-00479.jpg-->
-    
+
 
 
 
@@ -43223,7 +43230,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -43233,7 +43240,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -43290,7 +43297,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -43300,7 +43307,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -43357,7 +43364,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -43367,7 +43374,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -43424,7 +43431,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -43434,7 +43441,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -43491,7 +43498,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -43501,7 +43508,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -43558,7 +43565,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -43568,7 +43575,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -43625,7 +43632,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -43635,7 +43642,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -43692,7 +43699,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -43702,7 +43709,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -43759,7 +43766,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -43769,7 +43776,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -43826,7 +43833,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -43836,7 +43843,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -43878,9 +43885,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00480--mixed5b-00489.jpg-->
-    
+
 
 
 
@@ -44375,7 +44382,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -44385,7 +44392,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -44442,7 +44449,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -44452,7 +44459,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -44509,7 +44516,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -44519,7 +44526,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -44576,7 +44583,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -44586,7 +44593,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -44643,7 +44650,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -44653,7 +44660,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -44710,7 +44717,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -44720,7 +44727,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -44777,7 +44784,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -44787,7 +44794,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -44844,7 +44851,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -44854,7 +44861,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -44911,7 +44918,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -44921,7 +44928,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -44978,7 +44985,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -44988,7 +44995,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -45030,9 +45037,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00490--mixed5b-00499.jpg-->
-    
+
 
 
 
@@ -45537,7 +45544,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -45547,7 +45554,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -45604,7 +45611,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -45614,7 +45621,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -45671,7 +45678,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -45681,7 +45688,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -45738,7 +45745,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -45748,7 +45755,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -45805,7 +45812,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -45815,7 +45822,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -45872,7 +45879,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -45882,7 +45889,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -45939,7 +45946,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -45949,7 +45956,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -46006,7 +46013,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -46016,7 +46023,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -46073,7 +46080,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -46083,7 +46090,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -46140,7 +46147,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -46150,7 +46157,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -46192,9 +46199,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00500--mixed5b-00509.jpg-->
-    
+
 
 
 
@@ -46709,7 +46716,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -46719,7 +46726,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -46776,7 +46783,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -46786,7 +46793,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -46843,7 +46850,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -46853,7 +46860,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -46910,7 +46917,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -46920,7 +46927,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -46977,7 +46984,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -46987,7 +46994,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -47044,7 +47051,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -47054,7 +47061,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -47111,7 +47118,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -47121,7 +47128,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -47178,7 +47185,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -47188,7 +47195,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -47245,7 +47252,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -47255,7 +47262,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -47312,7 +47319,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -47322,7 +47329,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -47364,9 +47371,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00510--mixed5b-00519.jpg-->
-    
+
 
 
 
@@ -47891,7 +47898,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -47901,7 +47908,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -47958,7 +47965,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -47968,7 +47975,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -48025,7 +48032,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -48035,7 +48042,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -48092,7 +48099,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -48102,7 +48109,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -48159,7 +48166,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -48169,7 +48176,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -48226,7 +48233,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -48236,7 +48243,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -48293,7 +48300,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -48303,7 +48310,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -48360,7 +48367,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -48370,7 +48377,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -48427,7 +48434,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -48437,7 +48444,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -48494,7 +48501,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -48504,7 +48511,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -48546,9 +48553,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00520--mixed5b-00529.jpg-->
-    
+
 
 
 
@@ -49083,7 +49090,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -49093,7 +49100,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -49150,7 +49157,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -49160,7 +49167,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -49217,7 +49224,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -49227,7 +49234,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -49284,7 +49291,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -49294,7 +49301,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -49351,7 +49358,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -49361,7 +49368,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -49418,7 +49425,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -49428,7 +49435,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -49485,7 +49492,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -49495,7 +49502,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -49552,7 +49559,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -49562,7 +49569,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -49619,7 +49626,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -49629,7 +49636,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -49686,7 +49693,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -49696,7 +49703,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -49738,9 +49745,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00530--mixed5b-00539.jpg-->
-    
+
 
 
 
@@ -50285,7 +50292,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -50295,7 +50302,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -50352,7 +50359,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -50362,7 +50369,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -50419,7 +50426,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -50429,7 +50436,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -50486,7 +50493,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -50496,7 +50503,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -50553,7 +50560,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -50563,7 +50570,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -50620,7 +50627,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -50630,7 +50637,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -50687,7 +50694,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -50697,7 +50704,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -50754,7 +50761,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -50764,7 +50771,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -50821,7 +50828,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -50831,7 +50838,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -50888,7 +50895,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -50898,7 +50905,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -50940,9 +50947,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00540--mixed5b-00549.jpg-->
-    
+
 
 
 
@@ -51497,7 +51504,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -51507,7 +51514,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -51564,7 +51571,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -51574,7 +51581,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -51631,7 +51638,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -51641,7 +51648,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -51698,7 +51705,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -51708,7 +51715,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -51765,7 +51772,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -51775,7 +51782,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -51832,7 +51839,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -51842,7 +51849,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -51899,7 +51906,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -51909,7 +51916,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -51966,7 +51973,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -51976,7 +51983,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -52033,7 +52040,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -52043,7 +52050,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -52100,7 +52107,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -52110,7 +52117,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -52152,9 +52159,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00550--mixed5b-00559.jpg-->
-    
+
 
 
 
@@ -52719,7 +52726,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -52729,7 +52736,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -52786,7 +52793,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -52796,7 +52803,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -52853,7 +52860,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -52863,7 +52870,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -52920,7 +52927,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -52930,7 +52937,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -52987,7 +52994,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -52997,7 +53004,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -53054,7 +53061,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -53064,7 +53071,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -53121,7 +53128,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -53131,7 +53138,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -53188,7 +53195,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -53198,7 +53205,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -53255,7 +53262,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -53265,7 +53272,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -53322,7 +53329,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -53332,7 +53339,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -53374,9 +53381,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00560--mixed5b-00569.jpg-->
-    
+
 
 
 
@@ -53951,7 +53958,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -53961,7 +53968,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -54018,7 +54025,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -54028,7 +54035,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -54085,7 +54092,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -54095,7 +54102,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -54152,7 +54159,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -54162,7 +54169,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -54219,7 +54226,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -54229,7 +54236,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -54286,7 +54293,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -54296,7 +54303,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -54353,7 +54360,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -54363,7 +54370,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -54420,7 +54427,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -54430,7 +54437,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -54487,7 +54494,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -54497,7 +54504,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -54554,7 +54561,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -54564,7 +54571,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -54606,9 +54613,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00570--mixed5b-00579.jpg-->
-    
+
 
 
 
@@ -55193,7 +55200,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -55203,7 +55210,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -55260,7 +55267,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -55270,7 +55277,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -55327,7 +55334,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -55337,7 +55344,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -55394,7 +55401,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -55404,7 +55411,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -55461,7 +55468,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -55471,7 +55478,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -55528,7 +55535,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -55538,7 +55545,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -55595,7 +55602,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -55605,7 +55612,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -55662,7 +55669,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -55672,7 +55679,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -55729,7 +55736,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -55739,7 +55746,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -55796,7 +55803,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -55806,7 +55813,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -55848,9 +55855,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00580--mixed5b-00589.jpg-->
-    
+
 
 
 
@@ -56445,7 +56452,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -56455,7 +56462,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -56512,7 +56519,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -56522,7 +56529,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -56579,7 +56586,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -56589,7 +56596,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -56646,7 +56653,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -56656,7 +56663,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -56713,7 +56720,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -56723,7 +56730,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -56780,7 +56787,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -56790,7 +56797,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -56847,7 +56854,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -56857,7 +56864,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -56914,7 +56921,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -56924,7 +56931,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -56981,7 +56988,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -56991,7 +56998,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -57048,7 +57055,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -57058,7 +57065,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -57100,9 +57107,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00590--mixed5b-00599.jpg-->
-    
+
 
 
 
@@ -57707,7 +57714,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -57717,7 +57724,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -57774,7 +57781,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -57784,7 +57791,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -57841,7 +57848,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -57851,7 +57858,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -57908,7 +57915,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -57918,7 +57925,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -57975,7 +57982,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -57985,7 +57992,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -58042,7 +58049,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -58052,7 +58059,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -58109,7 +58116,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -58119,7 +58126,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -58176,7 +58183,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -58186,7 +58193,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -58243,7 +58250,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -58253,7 +58260,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -58310,7 +58317,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -58320,7 +58327,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -58362,9 +58369,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00600--mixed5b-00609.jpg-->
-    
+
 
 
 
@@ -58979,7 +58986,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -58989,7 +58996,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -59046,7 +59053,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -59056,7 +59063,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -59113,7 +59120,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -59123,7 +59130,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -59180,7 +59187,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -59190,7 +59197,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -59247,7 +59254,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -59257,7 +59264,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -59314,7 +59321,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -59324,7 +59331,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -59381,7 +59388,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -59391,7 +59398,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -59448,7 +59455,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -59458,7 +59465,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -59515,7 +59522,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -59525,7 +59532,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -59582,7 +59589,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -59592,7 +59599,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -59634,9 +59641,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00610--mixed5b-00619.jpg-->
-    
+
 
 
 
@@ -60261,7 +60268,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -60271,7 +60278,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -60328,7 +60335,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -60338,7 +60345,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -60395,7 +60402,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -60405,7 +60412,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -60462,7 +60469,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -60472,7 +60479,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -60529,7 +60536,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -60539,7 +60546,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -60596,7 +60603,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -60606,7 +60613,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -60663,7 +60670,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -60673,7 +60680,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -60730,7 +60737,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -60740,7 +60747,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -60797,7 +60804,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -60807,7 +60814,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -60864,7 +60871,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -60874,7 +60881,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -60916,9 +60923,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00620--mixed5b-00629.jpg-->
-    
+
 
 
 
@@ -61553,7 +61560,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -61563,7 +61570,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -61620,7 +61627,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -61630,7 +61637,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -61687,7 +61694,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -61697,7 +61704,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -61754,7 +61761,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -61764,7 +61771,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -61821,7 +61828,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -61831,7 +61838,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -61888,7 +61895,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -61898,7 +61905,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -61955,7 +61962,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -61965,7 +61972,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -62022,7 +62029,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -62032,7 +62039,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -62089,7 +62096,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -62099,7 +62106,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -62156,7 +62163,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -62166,7 +62173,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -62208,9 +62215,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00630--mixed5b-00639.jpg-->
-    
+
 
 
 
@@ -62855,7 +62862,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -62865,7 +62872,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -62922,7 +62929,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -62932,7 +62939,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -62989,7 +62996,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -62999,7 +63006,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -63056,7 +63063,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -63066,7 +63073,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -63123,7 +63130,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -63133,7 +63140,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -63190,7 +63197,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -63200,7 +63207,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -63257,7 +63264,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -63267,7 +63274,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -63324,7 +63331,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -63334,7 +63341,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -63391,7 +63398,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -63401,7 +63408,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -63458,7 +63465,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -63468,7 +63475,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -63510,9 +63517,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00640--mixed5b-00649.jpg-->
-    
+
 
 
 
@@ -64167,7 +64174,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -64177,7 +64184,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -64234,7 +64241,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -64244,7 +64251,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -64301,7 +64308,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -64311,7 +64318,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -64368,7 +64375,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -64378,7 +64385,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -64435,7 +64442,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -64445,7 +64452,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -64502,7 +64509,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -64512,7 +64519,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -64569,7 +64576,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -64579,7 +64586,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -64636,7 +64643,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -64646,7 +64653,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -64703,7 +64710,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -64713,7 +64720,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -64770,7 +64777,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -64780,7 +64787,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -64822,9 +64829,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00650--mixed5b-00659.jpg-->
-    
+
 
 
 
@@ -65489,7 +65496,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -65499,7 +65506,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -65556,7 +65563,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -65566,7 +65573,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -65623,7 +65630,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -65633,7 +65640,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -65690,7 +65697,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -65700,7 +65707,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -65757,7 +65764,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -65767,7 +65774,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -65824,7 +65831,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -65834,7 +65841,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -65891,7 +65898,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -65901,7 +65908,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -65958,7 +65965,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -65968,7 +65975,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -66025,7 +66032,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -66035,7 +66042,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -66092,7 +66099,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -66102,7 +66109,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -66144,9 +66151,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00660--mixed5b-00669.jpg-->
-    
+
 
 
 
@@ -66821,7 +66828,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -66831,7 +66838,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -66888,7 +66895,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -66898,7 +66905,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -66955,7 +66962,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -66965,7 +66972,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -67022,7 +67029,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -67032,7 +67039,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -67089,7 +67096,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -67099,7 +67106,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -67156,7 +67163,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -67166,7 +67173,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -67223,7 +67230,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -67233,7 +67240,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -67290,7 +67297,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -67300,7 +67307,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -67357,7 +67364,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -67367,7 +67374,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -67424,7 +67431,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -67434,7 +67441,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -67476,9 +67483,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00670--mixed5b-00679.jpg-->
-    
+
 
 
 
@@ -68163,7 +68170,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -68173,7 +68180,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -68230,7 +68237,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -68240,7 +68247,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -68297,7 +68304,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -68307,7 +68314,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -68364,7 +68371,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -68374,7 +68381,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -68431,7 +68438,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -68441,7 +68448,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -68498,7 +68505,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -68508,7 +68515,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -68565,7 +68572,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -68575,7 +68582,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -68632,7 +68639,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -68642,7 +68649,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -68699,7 +68706,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -68709,7 +68716,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -68766,7 +68773,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -68776,7 +68783,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -68818,9 +68825,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00680--mixed5b-00689.jpg-->
-    
+
 
 
 
@@ -69515,7 +69522,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -69525,7 +69532,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -69582,7 +69589,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -69592,7 +69599,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -69649,7 +69656,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -69659,7 +69666,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -69716,7 +69723,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -69726,7 +69733,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -69783,7 +69790,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -69793,7 +69800,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -69850,7 +69857,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -69860,7 +69867,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -69917,7 +69924,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -69927,7 +69934,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -69984,7 +69991,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -69994,7 +70001,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -70051,7 +70058,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -70061,7 +70068,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -70118,7 +70125,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -70128,7 +70135,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -70170,9 +70177,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00690--mixed5b-00699.jpg-->
-    
+
 
 
 
@@ -70877,7 +70884,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -70887,7 +70894,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -70944,7 +70951,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -70954,7 +70961,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -71011,7 +71018,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -71021,7 +71028,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -71078,7 +71085,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -71088,7 +71095,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -71145,7 +71152,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -71155,7 +71162,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -71212,7 +71219,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -71222,7 +71229,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -71279,7 +71286,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -71289,7 +71296,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -71346,7 +71353,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -71356,7 +71363,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -71413,7 +71420,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -71423,7 +71430,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -71480,7 +71487,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -71490,7 +71497,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -71532,9 +71539,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00700--mixed5b-00709.jpg-->
-    
+
 
 
 
@@ -72249,7 +72256,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -72259,7 +72266,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -72316,7 +72323,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -72326,7 +72333,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -72383,7 +72390,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -72393,7 +72400,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -72450,7 +72457,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -72460,7 +72467,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -72517,7 +72524,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -72527,7 +72534,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -72584,7 +72591,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -72594,7 +72601,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -72651,7 +72658,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -72661,7 +72668,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -72718,7 +72725,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -72728,7 +72735,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -72785,7 +72792,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -72795,7 +72802,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -72852,7 +72859,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -72862,7 +72869,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -72904,9 +72911,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00710--mixed5b-00719.jpg-->
-    
+
 
 
 
@@ -73631,7 +73638,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -73641,7 +73648,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -73698,7 +73705,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -73708,7 +73715,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -73765,7 +73772,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -73775,7 +73782,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -73832,7 +73839,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -73842,7 +73849,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -73899,7 +73906,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -73909,7 +73916,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -73966,7 +73973,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -73976,7 +73983,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -74033,7 +74040,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -74043,7 +74050,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -74100,7 +74107,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -74110,7 +74117,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -74167,7 +74174,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -74177,7 +74184,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -74234,7 +74241,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -74244,7 +74251,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -74286,9 +74293,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00720--mixed5b-00729.jpg-->
-    
+
 
 
 
@@ -75023,7 +75030,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -75033,7 +75040,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -75090,7 +75097,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -75100,7 +75107,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -75157,7 +75164,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -75167,7 +75174,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -75224,7 +75231,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -75234,7 +75241,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -75291,7 +75298,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -75301,7 +75308,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -75358,7 +75365,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -75368,7 +75375,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -75425,7 +75432,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -75435,7 +75442,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -75492,7 +75499,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -75502,7 +75509,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -75559,7 +75566,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -75569,7 +75576,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -75626,7 +75633,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -75636,7 +75643,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -75678,9 +75685,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00730--mixed5b-00739.jpg-->
-    
+
 
 
 
@@ -76425,7 +76432,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -76435,7 +76442,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -76492,7 +76499,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -76502,7 +76509,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -76559,7 +76566,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -76569,7 +76576,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -76626,7 +76633,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -76636,7 +76643,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -76693,7 +76700,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -76703,7 +76710,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -76760,7 +76767,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -76770,7 +76777,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -76827,7 +76834,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -76837,7 +76844,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -76894,7 +76901,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -76904,7 +76911,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -76961,7 +76968,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -76971,7 +76978,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -77028,7 +77035,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -77038,7 +77045,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -77080,9 +77087,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00740--mixed5b-00749.jpg-->
-    
+
 
 
 
@@ -77837,7 +77844,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -77847,7 +77854,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -77904,7 +77911,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -77914,7 +77921,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -77971,7 +77978,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -77981,7 +77988,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -78038,7 +78045,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -78048,7 +78055,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -78105,7 +78112,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -78115,7 +78122,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -78172,7 +78179,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -78182,7 +78189,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -78239,7 +78246,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -78249,7 +78256,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -78306,7 +78313,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -78316,7 +78323,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -78373,7 +78380,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -78383,7 +78390,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -78440,7 +78447,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -78450,7 +78457,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -78492,9 +78499,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00750--mixed5b-00759.jpg-->
-    
+
 
 
 
@@ -79259,7 +79266,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -79269,7 +79276,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -79326,7 +79333,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -79336,7 +79343,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -79393,7 +79400,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -79403,7 +79410,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -79460,7 +79467,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -79470,7 +79477,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -79527,7 +79534,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -79537,7 +79544,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -79594,7 +79601,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -79604,7 +79611,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -79661,7 +79668,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -79671,7 +79678,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -79728,7 +79735,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -79738,7 +79745,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -79795,7 +79802,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -79805,7 +79812,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -79862,7 +79869,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -79872,7 +79879,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -79914,9 +79921,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00760--mixed5b-00769.jpg-->
-    
+
 
 
 
@@ -80691,7 +80698,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -80701,7 +80708,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -80758,7 +80765,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -80768,7 +80775,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -80825,7 +80832,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -80835,7 +80842,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -80892,7 +80899,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -80902,7 +80909,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -80959,7 +80966,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -80969,7 +80976,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -81026,7 +81033,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -81036,7 +81043,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -81093,7 +81100,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -81103,7 +81110,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -81160,7 +81167,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -81170,7 +81177,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -81227,7 +81234,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -81237,7 +81244,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -81294,7 +81301,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -81304,7 +81311,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -81346,9 +81353,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00770--mixed5b-00779.jpg-->
-    
+
 
 
 
@@ -82133,7 +82140,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -82143,7 +82150,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -82200,7 +82207,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -82210,7 +82217,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -82267,7 +82274,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -82277,7 +82284,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -82334,7 +82341,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -82344,7 +82351,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -82401,7 +82408,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -82411,7 +82418,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -82468,7 +82475,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -82478,7 +82485,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -82535,7 +82542,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -82545,7 +82552,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -82602,7 +82609,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -82612,7 +82619,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -82669,7 +82676,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -82679,7 +82686,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -82736,7 +82743,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -82746,7 +82753,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -82788,9 +82795,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00780--mixed5b-00789.jpg-->
-    
+
 
 
 
@@ -83585,7 +83592,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -83595,7 +83602,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -83652,7 +83659,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -83662,7 +83669,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -83719,7 +83726,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -83729,7 +83736,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -83786,7 +83793,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -83796,7 +83803,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -83853,7 +83860,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -83863,7 +83870,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -83920,7 +83927,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -83930,7 +83937,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -83987,7 +83994,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -83997,7 +84004,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -84054,7 +84061,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -84064,7 +84071,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -84121,7 +84128,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -84131,7 +84138,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -84188,7 +84195,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -84198,7 +84205,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -84240,9 +84247,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00790--mixed5b-00799.jpg-->
-    
+
 
 
 
@@ -85047,7 +85054,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -85057,7 +85064,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -85114,7 +85121,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -85124,7 +85131,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -85181,7 +85188,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -85191,7 +85198,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -85248,7 +85255,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -85258,7 +85265,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -85315,7 +85322,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -85325,7 +85332,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -85382,7 +85389,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -85392,7 +85399,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -85449,7 +85456,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -85459,7 +85466,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -85516,7 +85523,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -85526,7 +85533,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -85583,7 +85590,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -85593,7 +85600,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -85650,7 +85657,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -85660,7 +85667,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -85702,9 +85709,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00800--mixed5b-00809.jpg-->
-    
+
 
 
 
@@ -86519,7 +86526,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -86529,7 +86536,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -86586,7 +86593,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -86596,7 +86603,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -86653,7 +86660,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -86663,7 +86670,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -86720,7 +86727,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -86730,7 +86737,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -86787,7 +86794,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -86797,7 +86804,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -86854,7 +86861,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -86864,7 +86871,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -86921,7 +86928,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -86931,7 +86938,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -86988,7 +86995,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -86998,7 +87005,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -87055,7 +87062,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -87065,7 +87072,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -87122,7 +87129,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -87132,7 +87139,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -87174,9 +87181,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00810--mixed5b-00819.jpg-->
-    
+
 
 
 
@@ -88001,7 +88008,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -88011,7 +88018,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -88068,7 +88075,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -88078,7 +88085,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -88135,7 +88142,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -88145,7 +88152,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -88202,7 +88209,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -88212,7 +88219,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -88269,7 +88276,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -88279,7 +88286,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -88336,7 +88343,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -88346,7 +88353,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -88403,7 +88410,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -88413,7 +88420,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -88470,7 +88477,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -88480,7 +88487,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -88537,7 +88544,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -88547,7 +88554,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -88604,7 +88611,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -88614,7 +88621,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -88656,9 +88663,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00820--mixed5b-00829.jpg-->
-    
+
 
 
 
@@ -89493,7 +89500,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -89503,7 +89510,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -89560,7 +89567,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -89570,7 +89577,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -89627,7 +89634,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -89637,7 +89644,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -89694,7 +89701,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -89704,7 +89711,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -89761,7 +89768,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -89771,7 +89778,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -89828,7 +89835,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -89838,7 +89845,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -89895,7 +89902,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -89905,7 +89912,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -89962,7 +89969,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -89972,7 +89979,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -90029,7 +90036,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -90039,7 +90046,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -90096,7 +90103,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -90106,7 +90113,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -90148,9 +90155,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00830--mixed5b-00839.jpg-->
-    
+
 
 
 
@@ -90995,7 +91002,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -91005,7 +91012,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -91062,7 +91069,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -91072,7 +91079,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -91129,7 +91136,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -91139,7 +91146,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -91196,7 +91203,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -91206,7 +91213,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -91263,7 +91270,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -91273,7 +91280,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -91330,7 +91337,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -91340,7 +91347,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -91397,7 +91404,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -91407,7 +91414,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -91464,7 +91471,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -91474,7 +91481,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -91531,7 +91538,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -91541,7 +91548,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -91598,7 +91605,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -91608,7 +91615,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -91650,9 +91657,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00840--mixed5b-00849.jpg-->
-    
+
 
 
 
@@ -92507,7 +92514,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -92517,7 +92524,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -92574,7 +92581,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -92584,7 +92591,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -92641,7 +92648,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -92651,7 +92658,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -92708,7 +92715,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -92718,7 +92725,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -92775,7 +92782,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -92785,7 +92792,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -92842,7 +92849,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -92852,7 +92859,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -92909,7 +92916,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -92919,7 +92926,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -92976,7 +92983,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -92986,7 +92993,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -93043,7 +93050,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -93053,7 +93060,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -93110,7 +93117,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -93120,7 +93127,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -93162,9 +93169,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00850--mixed5b-00859.jpg-->
-    
+
 
 
 
@@ -94029,7 +94036,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -94039,7 +94046,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -94096,7 +94103,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -94106,7 +94113,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -94163,7 +94170,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -94173,7 +94180,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -94230,7 +94237,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -94240,7 +94247,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -94297,7 +94304,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -94307,7 +94314,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -94364,7 +94371,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -94374,7 +94381,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -94431,7 +94438,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -94441,7 +94448,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -94498,7 +94505,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -94508,7 +94515,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -94565,7 +94572,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -94575,7 +94582,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -94632,7 +94639,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -94642,7 +94649,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -94684,9 +94691,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00860--mixed5b-00869.jpg-->
-    
+
 
 
 
@@ -95561,7 +95568,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -95571,7 +95578,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -95628,7 +95635,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -95638,7 +95645,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -95695,7 +95702,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -95705,7 +95712,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -95762,7 +95769,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -95772,7 +95779,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -95829,7 +95836,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -95839,7 +95846,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -95896,7 +95903,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -95906,7 +95913,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -95963,7 +95970,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -95973,7 +95980,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -96030,7 +96037,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -96040,7 +96047,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -96097,7 +96104,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -96107,7 +96114,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -96164,7 +96171,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -96174,7 +96181,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -96216,9 +96223,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00870--mixed5b-00879.jpg-->
-    
+
 
 
 
@@ -97103,7 +97110,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -97113,7 +97120,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -97170,7 +97177,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -97180,7 +97187,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -97237,7 +97244,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -97247,7 +97254,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -97304,7 +97311,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -97314,7 +97321,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -97371,7 +97378,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -97381,7 +97388,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -97438,7 +97445,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -97448,7 +97455,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -97505,7 +97512,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -97515,7 +97522,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -97572,7 +97579,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -97582,7 +97589,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -97639,7 +97646,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -97649,7 +97656,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -97706,7 +97713,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -97716,7 +97723,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -97758,9 +97765,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00880--mixed5b-00889.jpg-->
-    
+
 
 
 
@@ -98655,7 +98662,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -98665,7 +98672,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -98722,7 +98729,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -98732,7 +98739,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -98789,7 +98796,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -98799,7 +98806,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -98856,7 +98863,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -98866,7 +98873,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -98923,7 +98930,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -98933,7 +98940,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -98990,7 +98997,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -99000,7 +99007,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -99057,7 +99064,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -99067,7 +99074,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -99124,7 +99131,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -99134,7 +99141,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -99191,7 +99198,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -99201,7 +99208,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -99258,7 +99265,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -99268,7 +99275,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -99310,9 +99317,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00890--mixed5b-00899.jpg-->
-    
+
 
 
 
@@ -100217,7 +100224,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -100227,7 +100234,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -100284,7 +100291,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -100294,7 +100301,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -100351,7 +100358,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -100361,7 +100368,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -100418,7 +100425,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -100428,7 +100435,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -100485,7 +100492,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -100495,7 +100502,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -100552,7 +100559,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -100562,7 +100569,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -100619,7 +100626,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -100629,7 +100636,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -100686,7 +100693,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -100696,7 +100703,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -100753,7 +100760,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -100763,7 +100770,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -100820,7 +100827,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -100830,7 +100837,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -100872,9 +100879,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00900--mixed5b-00909.jpg-->
-    
+
 
 
 
@@ -101789,7 +101796,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -101799,7 +101806,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -101856,7 +101863,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -101866,7 +101873,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -101923,7 +101930,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -101933,7 +101940,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -101990,7 +101997,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -102000,7 +102007,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -102057,7 +102064,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -102067,7 +102074,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -102124,7 +102131,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -102134,7 +102141,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -102191,7 +102198,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -102201,7 +102208,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -102258,7 +102265,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -102268,7 +102275,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -102325,7 +102332,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -102335,7 +102342,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -102392,7 +102399,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -102402,7 +102409,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -102444,9 +102451,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00910--mixed5b-00919.jpg-->
-    
+
 
 
 
@@ -103371,7 +103378,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -103381,7 +103388,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -103438,7 +103445,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -103448,7 +103455,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -103505,7 +103512,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -103515,7 +103522,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -103572,7 +103579,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -103582,7 +103589,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -103639,7 +103646,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -103649,7 +103656,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -103706,7 +103713,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -103716,7 +103723,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -103773,7 +103780,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -103783,7 +103790,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -103840,7 +103847,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -103850,7 +103857,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -103907,7 +103914,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -103917,7 +103924,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -103974,7 +103981,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -103984,7 +103991,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -104026,9 +104033,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00920--mixed5b-00929.jpg-->
-    
+
 
 
 
@@ -104963,7 +104970,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -104973,7 +104980,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -105030,7 +105037,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -105040,7 +105047,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -105097,7 +105104,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -105107,7 +105114,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -105164,7 +105171,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -105174,7 +105181,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -105231,7 +105238,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -105241,7 +105248,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -105298,7 +105305,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -105308,7 +105315,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -105365,7 +105372,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -105375,7 +105382,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -105432,7 +105439,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -105442,7 +105449,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -105499,7 +105506,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -105509,7 +105516,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -105566,7 +105573,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -105576,7 +105583,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -105618,9 +105625,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00930--mixed5b-00939.jpg-->
-    
+
 
 
 
@@ -106565,7 +106572,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -106575,7 +106582,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -106632,7 +106639,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -106642,7 +106649,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -106699,7 +106706,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -106709,7 +106716,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -106766,7 +106773,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -106776,7 +106783,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -106833,7 +106840,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -106843,7 +106850,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -106900,7 +106907,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -106910,7 +106917,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -106967,7 +106974,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -106977,7 +106984,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -107034,7 +107041,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -107044,7 +107051,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -107101,7 +107108,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -107111,7 +107118,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -107168,7 +107175,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -107178,7 +107185,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -107220,9 +107227,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00940--mixed5b-00949.jpg-->
-    
+
 
 
 
@@ -108177,7 +108184,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -108187,7 +108194,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -108244,7 +108251,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -108254,7 +108261,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -108311,7 +108318,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -108321,7 +108328,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -108378,7 +108385,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -108388,7 +108395,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -108445,7 +108452,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -108455,7 +108462,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -108512,7 +108519,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -108522,7 +108529,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -108579,7 +108586,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -108589,7 +108596,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -108646,7 +108653,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -108656,7 +108663,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -108713,7 +108720,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -108723,7 +108730,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -108780,7 +108787,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -108790,7 +108797,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -108832,9 +108839,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00950--mixed5b-00959.jpg-->
-    
+
 
 
 
@@ -109799,7 +109806,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -109809,7 +109816,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -109866,7 +109873,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -109876,7 +109883,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -109933,7 +109940,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -109943,7 +109950,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -110000,7 +110007,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -110010,7 +110017,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -110067,7 +110074,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -110077,7 +110084,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -110134,7 +110141,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -110144,7 +110151,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -110201,7 +110208,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -110211,7 +110218,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -110268,7 +110275,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -110278,7 +110285,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -110335,7 +110342,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -110345,7 +110352,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -110402,7 +110409,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -110412,7 +110419,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -110454,9 +110461,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00960--mixed5b-00969.jpg-->
-    
+
 
 
 
@@ -111431,7 +111438,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -111441,7 +111448,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -111498,7 +111505,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -111508,7 +111515,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -111565,7 +111572,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -111575,7 +111582,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -111632,7 +111639,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -111642,7 +111649,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -111699,7 +111706,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -111709,7 +111716,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -111766,7 +111773,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -111776,7 +111783,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -111833,7 +111840,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -111843,7 +111850,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -111900,7 +111907,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -111910,7 +111917,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -111967,7 +111974,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -111977,7 +111984,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -112034,7 +112041,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -112044,7 +112051,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -112086,9 +112093,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00970--mixed5b-00979.jpg-->
-    
+
 
 
 
@@ -113073,7 +113080,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -113083,7 +113090,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -113140,7 +113147,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -113150,7 +113157,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -113207,7 +113214,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -113217,7 +113224,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -113274,7 +113281,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -113284,7 +113291,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -113341,7 +113348,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -113351,7 +113358,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -113408,7 +113415,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -113418,7 +113425,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -113475,7 +113482,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -113485,7 +113492,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -113542,7 +113549,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -113552,7 +113559,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -113609,7 +113616,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -113619,7 +113626,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -113676,7 +113683,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -113686,7 +113693,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -113728,9 +113735,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00980--mixed5b-00989.jpg-->
-    
+
 
 
 
@@ -114725,7 +114732,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -114735,7 +114742,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -114792,7 +114799,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -114802,7 +114809,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -114859,7 +114866,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -114869,7 +114876,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -114926,7 +114933,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -114936,7 +114943,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -114993,7 +115000,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -115003,7 +115010,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -115060,7 +115067,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -115070,7 +115077,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -115127,7 +115134,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -115137,7 +115144,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -115194,7 +115201,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -115204,7 +115211,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -115261,7 +115268,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -115271,7 +115278,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -115328,7 +115335,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -115338,7 +115345,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -115380,9 +115387,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-00990--mixed5b-00999.jpg-->
-    
+
 
 
 
@@ -116387,7 +116394,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -116397,7 +116404,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -116454,7 +116461,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -116464,7 +116471,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -116521,7 +116528,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -116531,7 +116538,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -116588,7 +116595,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -116598,7 +116605,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -116655,7 +116662,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -116665,7 +116672,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -116722,7 +116729,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -116732,7 +116739,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -116789,7 +116796,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -116799,7 +116806,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -116856,7 +116863,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -116866,7 +116873,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -116923,7 +116930,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -116933,7 +116940,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -116990,7 +116997,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -117000,7 +117007,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -117042,9 +117049,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-01000--mixed5b-01009.jpg-->
-    
+
 
 
 
@@ -118059,7 +118066,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -118069,7 +118076,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -118126,7 +118133,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -118136,7 +118143,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -118193,7 +118200,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -118203,7 +118210,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -118260,7 +118267,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -118270,7 +118277,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -118327,7 +118334,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -118337,7 +118344,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -118394,7 +118401,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -118404,7 +118411,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -118461,7 +118468,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -118471,7 +118478,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -118528,7 +118535,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -118538,7 +118545,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -118595,7 +118602,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -118605,7 +118612,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -118662,7 +118669,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -118672,7 +118679,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -118714,9 +118721,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-01010--mixed5b-01019.jpg-->
-    
+
 
 
 
@@ -119741,7 +119748,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -119751,7 +119758,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -119808,7 +119815,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -119818,7 +119825,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -119875,7 +119882,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -119885,7 +119892,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -119942,7 +119949,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -119952,7 +119959,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -120009,7 +120016,7 @@
           <div class="sprite channel index-4"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-4"></div>
@@ -120019,7 +120026,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-4 dataset-index-0"></div>
@@ -120076,7 +120083,7 @@
           <div class="sprite channel index-5"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-5"></div>
@@ -120086,7 +120093,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-5 dataset-index-0"></div>
@@ -120143,7 +120150,7 @@
           <div class="sprite channel index-6"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-6"></div>
@@ -120153,7 +120160,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-6 dataset-index-0"></div>
@@ -120210,7 +120217,7 @@
           <div class="sprite channel index-7"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-7"></div>
@@ -120220,7 +120227,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-7 dataset-index-0"></div>
@@ -120277,7 +120284,7 @@
           <div class="sprite channel index-8"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-8"></div>
@@ -120287,7 +120294,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-8 dataset-index-0"></div>
@@ -120344,7 +120351,7 @@
           <div class="sprite channel index-9"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-9"></div>
@@ -120354,7 +120361,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-9 dataset-index-0"></div>
@@ -120396,9 +120403,9 @@
       </div>
       </d-figure>
       </li>
-  
+
     <!--mixed5b-01020--mixed5b-01023.jpg-->
-    
+
 
 
 
@@ -121433,7 +121440,7 @@
           <div class="sprite channel index-0"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-0"></div>
@@ -121443,7 +121450,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-0 dataset-index-0"></div>
@@ -121500,7 +121507,7 @@
           <div class="sprite channel index-1"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-1"></div>
@@ -121510,7 +121517,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-1 dataset-index-0"></div>
@@ -121567,7 +121574,7 @@
           <div class="sprite channel index-2"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-2"></div>
@@ -121577,7 +121584,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-2 dataset-index-0"></div>
@@ -121634,7 +121641,7 @@
           <div class="sprite channel index-3"></div>
           <span class="figcaption">Channel Objective</span>
         </div>
-        
+
         <div>
           <div class="diversity">
             <div class="sprite channel-diversity-0 index-3"></div>
@@ -121644,7 +121651,7 @@
           </div>
           <span class="figcaption">Diversity</span>
         </div>
-        
+
         <div>
           <div class="dataset-examples dataset-positive">
             <div class="sprite index-3 dataset-index-0"></div>
@@ -121686,9 +121693,8 @@
       </div>
       </d-figure>
       </li>
-  
+
   </ul>
   </d-article>
   <distill-footer></distill-footer>
 </body>
-  


### PR DESCRIPTION
When viewing a GoogLeNet concat layer, this PR displays information about the branches the layer is composed of and links to the first neuron for each branch.

It also causes the present layer to be bolded.

![image](https://user-images.githubusercontent.com/61658/52383337-c778fa00-2a2d-11e9-9325-01acf8a147b9.png)

The diff is unreasonably large because atom decided to delete all unused whitespace. :/